### PR TITLE
Fix parameter names for FPGA and AWG markers

### DIFF
--- a/qtt/instrument_drivers/virtual_awg.py
+++ b/qtt/instrument_drivers/virtual_awg.py
@@ -234,7 +234,8 @@ class virtual_awg(Instrument):
             end = int(np.floor(width * len(data) - 1))
             data_processed = data[1:end]
         elif direction == 'backwards':
-            data_processed = data[int(np.ceil((1 - width) * len(data))):]
+            begin = int(np.ceil((1 - width) * len(data)))
+            data_processed = data[begin:]
 
         return data_processed
 


### PR DESCRIPTION
Fix for parameter names of markers on awg channels in virtual_awg class
