### PR TITLE
change `set_sq_length` method to parameter `sequence_length`

### DIFF
--- a/qtt/instrument_drivers/virtual_awg.py
+++ b/qtt/instrument_drivers/virtual_awg.py
@@ -43,7 +43,7 @@ class virtual_awg(Instrument):
             self.awg_cont.set('run_mode', 'CONT')
             self.awg_seq = self._awgs[(self.awg_map['awg_mk'][0] + 1) % 2]
             self.awg_seq.set('run_mode', 'SEQ')
-            self.awg_seq.set_sq_length(1)
+            self.awg_seq.sequence_length.set(1)
             self.awg_seq.set_sqel_trigger_wait(1,0)
             self.delay_AWG = self.hardware.parameters['delay_AWG'].get()
         else:


### PR DESCRIPTION
minor fix for compatibility with new AWG 5014 driver