### PR TITLE
Fix/gates validators

### DIFF
--- a/qtt/instrument_drivers/gates.py
+++ b/qtt/instrument_drivers/gates.py
@@ -111,7 +111,7 @@ class virtual_IVVI(Instrument):
             param = self.get_instrument_parameter(g)
             param._vals = Numbers(bnds[0], max_value=bnds[1])
             if hasattr(instrument, 'adjust_validator_resolution'):
-                param = instrument.adjust_validator_resolution(param)
+                instrument.adjust_validator_resolution(param)
 
     def __repr__(self):
         gm = getattr(self, '_gate_map', [])


### PR DESCRIPTION
@peendebak To adjust the dac validator range based on the finite resolution.

In `set_boundaries` the IVVI function `adjust_validator_range` will be used if available.