### PR TITLE
add fast readout mode for gates

### DIFF
--- a/qtt/instrument_drivers/gates.py
+++ b/qtt/instrument_drivers/gates.py
@@ -62,11 +62,14 @@ class virtual_IVVI(Instrument):
             if verbose:
                 print('%s: %f' % (gate, self.get(gate)))
 
-    def _get(self, gate):
+    def _get(self, gate, fast_readout = False):
         gatemap = self._gate_map[gate]
         gate = 'dac%d' % gatemap[1]
         logging.debug('_get: %s %s' % (gatemap[0], gate))
-        return self._instrument_list[gatemap[0]].get(gate)
+        if fast_readout:
+            return self._instrument_list[gatemap[0]].get_latest(gate)
+        else:
+            return self._instrument_list[gatemap[0]].get(gate)
 
     def _set(self, value, gate):
         logging.debug('gate._set: gate %s, value %s' % (gate, value))
@@ -207,3 +210,5 @@ class virtual_IVVI(Instrument):
             dot.edge(str(g), str(ix))
 
         return dot
+    
+    


### PR DESCRIPTION
Make gates and virtual gates faster by preventing unnecessary gets on the physical gates. The approach is to replace a `.get` with `.get_latest` where possible. Open for discussion. @CJvanDiepen @takafumifujita 

-	The virtual gates are mapped to the gates object, which is mapped to one or more IVVI and spi racks. This means the approach fails if someone does a direct `set` on the ivvi or spi instrument. 
-	For the IVVI and SPI racks we can do: `ivvi.set(200)`. Then `ivvi.get_latest()` will be 200. If we do a `ivvi.get()` we get 200.00123 (some value close to 200 but rounded to the DACs precision). And if we do a` ivvi.get_latest()` again we will get the 200.00123. So if we speed up things by using `get_latest` we will almost surely get values that are slightly wrong.
