### PR TITLE
Fix for 2D vector scans in calculation of physical gate values.

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -668,8 +668,8 @@ class scanjob_t(dict):
             if self['scantype'] in ['scan2Dvec', 'scan2Dfastvec', 'scan2Dturbovec']:
                 param_init = {param: gates.get(param) for param in sweepdata['param']}
                 self['phys_gates_vals'] = {param: np.zeros((len(stepvalues), len(sweepvalues))) for param in sweepdata['param']}
-                step_array2d = np.tile(np.arange(-stepdata['range']/2, stepdata['range']/2, stepdata['step']).reshape(-1, 1), (1, len(sweepvalues)))
-                sweep_array2d = np.tile(np.arange(-sweepdata['range']/2, sweepdata['range']/2, sweepdata['step']), (len(stepvalues), 1))   
+                step_array2d = np.tile(np.array(stepvalues).reshape(-1, 1), (1, len(sweepvalues)))
+                sweep_array2d = np.tile(sweepvalues, (len(stepvalues), 1))   
                 for param in sweepdata['param']:
                     self['phys_gates_vals'][param] = param_init[param] + step_array2d * stepdata['param'][param] + sweep_array2d * sweepdata['param'][param]    
             self['stepdata'] = stepdata


### PR DESCRIPTION
@peendebak This should fix issue #112.

When using the same piece of example code: 
```
from qtt.scans import *
from qcodes import ManualParameter
from qcodes.instrument_drivers.devices import VoltageDivider
from qtt.instrument_drivers.virtual_instruments import VirtualIVVI
import qcodes
import qtt.measurements.scans
from qtt.measurements.scans import scanjob_t

p = ManualParameter('p'); q = ManualParameter('q')
R=VoltageDivider(p, 4)
gates=VirtualIVVI(name=qtt.measurements.scans.instrumentName('gates'), model=None)
station = qcodes.Station(gates)
station.gates=gates

scanjob = scanjob_t({'minstrument': [R]})
scanjob['sweepdata']={'start': 0, 'range': 100, 'end': 100, 'param': {'dac1': 1.0, 'dac2': 0}, 'wait_time': 0.2, 'step': 0.10775862068965517}
scanjob['stepdata'] = dict({'param': 'dac3', 'start': 24, 'end': 30, 'step': 1.})
data = scan2D(station, scanjob, liveplotwindow=False, verbose=0)
```
I do get the following error: 
```
Traceback (most recent call last):

  File "<ipython-input-1-579af259eabc>", line 18, in <module>
    data = scan2D(station, scanjob, liveplotwindow=False, verbose=0)

  File "C:\Users\diepencjv\repos\qutech\qtt\qtt\measurements\scans.py", line 791, in scan2D
    value = p.get()

  File "C:\Users\diepencjv\repos\qutech\Qcodes\qcodes\instrument_drivers\devices.py", line 83, in get
    value = self.v1.get() / self.division_value

TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```