### PR TITLE
Add PAT scan functionality to scan2Dfast

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -598,7 +598,8 @@ class scanjob_t(dict):
                     scaninfo['start'] = -scaninfo['range']/2
                     scaninfo['end'] = scaninfo['range']/2
                 else:
-                    pass
+                    scaninfo['start'] = -scaninfo['range']/2
+                    scaninfo['end'] = scaninfo['range']/2
 
     def _parse_2Dvec(self):
         """ Adjust the parameter field in the step- and sweepdata for 2D vector scans.
@@ -685,9 +686,15 @@ class scanjob_t(dict):
             else:
                 raise Exception('unknown scantype')
             if sweeplength is not None:
-                sweepdata['step'] = (sweepdata['end'] - sweepdata['start']) / sweeplength
+                if 'range' in sweepdata:
+                    sweepdata['step'] = sweepdata['range'] / sweeplength
+                else:
+                    sweepdata['step'] = (sweepdata['end'] - sweepdata['start']) / sweeplength
             if steplength is not None:
-                stepdata['step'] = (stepdata['end'] - stepdata['start']) / steplength
+                if 'range' in stepdata:
+                    stepdata['step'] = stepdata['range'] / steplength
+                else:
+                    stepdata['step'] = (stepdata['end'] - stepdata['start']) / steplength
 
             sweepvalues = sweepparam[sweepdata['start']:sweepdata['end']:sweepdata['step']]
             stepvalues = stepparam[stepdata['start']:stepdata['end']:stepdata['step']]


### PR DESCRIPTION
@peendebak @brunobuijtendorp The PAT scan functionality is available in `scan2Dfast`. Syntax for the scan is:
```
scanjob = {'sweepdata': {'param': {'P1':1 , 'P2': -1}, 'range': 30}
scanjob['stepdata'] = {'param': mwsource.frequency, 'start': 1, 'end': 20, 'step': 1}
scan2Dfast(station, scanjob)
```
Currently it is not possible to also vary the power of the microwave source during the scan, but that does also not seem necessary for the triple dot.