### PR TITLE
Pol fit with nonlinear least squares

### DIFF
--- a/qtt/algorithms/tunneling.py
+++ b/qtt/algorithms/tunneling.py
@@ -57,7 +57,7 @@ def polweight_all_2slopes(x_data, y_data, par, kT):
     return total
 
 
-def fit_pol_all(x_data, y_data, kT, maxiter=None, maxfun=5000, verbose=1, par_guess=None, method='fmin'):
+def fit_pol_all(x_data, y_data, kT, maxiter=None, maxfun=5000, verbose=1, par_guess=None, method='fmin', returnextra=False):
     """ Polarization line fitting. 
 
     The default value for the maxiter argument of scipy.optimize.fmin is N*200
@@ -97,7 +97,10 @@ def fit_pol_all(x_data, y_data, kT, maxiter=None, maxfun=5000, verbose=1, par_gu
     else:
         raise Exception('Unrecognized fitting method')
         
-    return par_fit, par_guess, fitdata
+    if returnextra:
+        return par_fit, par_guess, fitdata
+    else:
+        return par_fit, par_guess
 
 
 def data_to_exc_ch(x_data, y_data, pol_fit):


### PR DESCRIPTION
@CJvanDiepen @peendebak I added to `fit_pol_all` an option to use an additional fitting method (`curve_fit`), which applies a non-linear least squares estimation. This allows us to extract the covariance matrix, from which we can extract uncertainties for each of the fitting parameters.
Can be run as: `par_fit, par_cov, _ = fit_pol_all(delta, signal, kT, method='curve_fit')`
And the standard deviation for each parameter can be extracted: `sigma = np.sqrt(par_cov[0.0])` (i.e. for the uncertainty in the tunnel coupling).
Currently the docs don't include the optional arguments, but I could add an explanation of the `method` argument in `fit_pol_all`. Should I do that?