### PR TITLE
Error when running normal gate scans with range

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -1334,7 +1334,7 @@ def scan2Dfast(station, scanjob, location=None, liveplotwindow=None, plotparam='
             sweepgate_value = (sweepdata['start'] + sweepdata['end']) / 2
             sweepdata['param'].set(float(sweepgate_value))
         waveform, sweep_info = station.awg.sweep_gate(
-            sweepdata['paramname'], sweeprange, period)
+            sweepdata['param'].name, sweeprange, period)
 
     data = measuresegment(waveform, Naverage, minstrhandle, read_ch)
     if len(read_ch) == 1:


### PR DESCRIPTION
With the new way of parsing `stepdata` and `sweepdata`, the `param` key now gets assigned a `StandardParameter` directly instead of the gate name. This was causing an error for the cases where a non-vector gate is used, and `range` is used instead of `start` and `end` in `scanjob`.
This changes should fix the issue for these cases.

@peendebak @CJvanDiepen 