### PR TITLE
Liveplotalpha

### DIFF
--- a/qtt/live_plotting.py
+++ b/qtt/live_plotting.py
@@ -534,11 +534,13 @@ class livePlot:
     def enable_averaging(self, *args, **kwargs):
         
         self._averaging_enabled = lp.win.averaging_box.checkState()
-        if self._averaging_enabled == 2:
-            print('enable_averaging called, alpha = '+str(self.alpha))
-        if self._averaging_enabled == 0:
-            print('enable_averaging called, averaging turned off')
-  
+        if self.verbose>=1:
+            if self._averaging_enabled == 2:
+                print('enable_averaging called, alpha = '+str(self.alpha))
+            elif self._averaging_enabled == 0:
+                print('enable_averaging called, averaging turned off')
+            else:
+                print('enable_averaging called, undefined')
     
     def startreadout(self, callback=None, rate=30, maxidx=None):
         """


### PR DESCRIPTION
@jpdehollain 
@peendebak 
@CJvanDiepen 
@Christian-Volk 

Added the parameter alpha to the class livePlot.  alpha has a value between 0 and 1and determines the weight given in averaging to the latest measurement result (alpha) and the previous measurement result (1-alpha), default value 0.3

the averaging can be turned on by checking the box in the gui, the value of alpha can be adjusted in the comment line. 
