### PR TITLE
Changed diffDataset to pass on the smoothing parameter sigma. Changed…

### DIFF
--- a/qtt/data.py
+++ b/qtt/data.py
@@ -133,7 +133,7 @@ def uniqueArrayName(dataset, name0):
 from qcodes.plots.qcmatplotlib import MatPlot
 
 
-def diffDataset(alldata, diff_dir='y', fig=None, meas_arr_name='measured'):
+def diffDataset(alldata, diff_dir='y', sigma=2, fig=None, meas_arr_name='measured'):
     """ Differentiate a dataset and plot the result.
 
     Args:
@@ -141,10 +141,11 @@ def diffDataset(alldata, diff_dir='y', fig=None, meas_arr_name='measured'):
         diff_dir (str): direction to differentiate in
         meas_arr_name (str): name of the measured array to be differentiated
         fig (int): the number for the figure to plot
+        sigma (float):  parameter for gaussian filter kernel
     """
     meas_arr_name = alldata.default_parameter_name(meas_arr_name)
     meas_array = alldata.arrays[meas_arr_name]
-    imx = qtt.diffImageSmooth(meas_array.ndarray, dy=diff_dir)
+    imx = qtt.diffImageSmooth(meas_array.ndarray, dy=diff_dir, sigma=sigma)
     name = 'diff_dir_%s' % diff_dir
     name = uniqueArrayName(alldata, name)
     data_arr = qcodes.DataArray(

--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -1344,7 +1344,7 @@ def scan2Dfast(station, scanjob, location=None, liveplotwindow=None, plotparam='
         else:
             sweeprange = (sweepdata['end'] - sweepdata['start'])
             sweepgate_value = (sweepdata['start'] + sweepdata['end']) / 2
-            gates.set(sweepdata['param'], float(sweepgate_value))
+            gates.set(sweepdata['paramname'], float(sweepgate_value))
         if 'pulsedata' in scanjob:
             waveform, sweep_info = station.awg.sweepandpulse_gate(
                 {'gate':sweepdata['param'].name, 'sweeprange':sweeprange, 'period':period},

--- a/qtt/tools.py
+++ b/qtt/tools.py
@@ -220,7 +220,7 @@ def diffImageSmooth(im, dy='x', sigma=2):
     dy : string or integer
         direction of differentiation. can be 'x' (0) or 'y' (1) or 'xy' (2)
     sigma : float
-        parameter for differentiation kernel
+        parameter for gaussian filter kernel
 
     """
     if sigma is None:


### PR DESCRIPTION
@peendebak @azwerver @CJvanDiepen 
Changed "diffDataset" to pass on the smoothing parameter sigma (a Gaussian filter is used before differentiating). Before it was hardcoded to sigma=2, now it can be changed. 
In scan2Dfast sweepdata['param'] changed to sweepdata['paramname']. Change was necessary to run scans with a single gate (not a dict combination of gates). I do not know why it does not work with 'param' anymore as it did before.
[Christian]