### PR TITLE
fix bug in liveplot; convert to Parameter instead of StandardParameter

### DIFF
--- a/qtt/live_plotting.py
+++ b/qtt/live_plotting.py
@@ -533,7 +533,7 @@ class livePlot:
         
     def enable_averaging(self, *args, **kwargs):
         
-        self._averaging_enabled = lp.win.averaging_box.checkState()
+        self._averaging_enabled = self.win.averaging_box.checkState()
         if self.verbose>=1:
             if self._averaging_enabled == 2:
                 print('enable_averaging called, alpha = '+str(self.alpha))

--- a/qtt/measurements/videomode.py
+++ b/qtt/measurements/videomode.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy import ndimage
 
 import qtt
-from qcodes.instrument.parameter import StandardParameter
+from qcodes.instrument.parameter import Parameter
 from qcodes.utils.validators import Numbers
 from qtt.live_plotting import livePlot
 from qtt.tools import connect_slot
@@ -92,7 +92,7 @@ class VideoMode:
         self.sweepparams = sweepparams
         self.sweepranges = sweepranges
         self.fpga_ch = minstrument
-        self.Naverage = StandardParameter('Naverage', get_cmd=self._get_Naverage, set_cmd=self._set_Naverage, vals=Numbers(1, 1023))
+        self.Naverage = Parameter('Naverage', get_cmd=self._get_Naverage, set_cmd=self._set_Naverage, vals=Numbers(1, 1023))
         self._Naverage_val = Naverage
         self.resolution = resolution
         self.sample_rate = sample_rate


### PR DESCRIPTION
@fvanriggelen Not sure how the bug could have stayed in our code as we did test it. The bug is on line 536 of `live_plotting.py`