### PR TITLE
small changes scan2D

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -962,7 +962,7 @@ def scan2D(station, scanjob, location=None, liveplotwindow=None, plotparam='meas
             
             alldata.store((ix,iy), datapoint)
             
-            if not (update_period is None):
+            if update_period is not None:
                 delta, tprev, update = delta_time(tprev, thr=update_period)
                 
                 if update and liveplotwindow:


### PR DESCRIPTION
Some proposed changes to scan2D relevant for our large, slow maps:
1. accept plot param 'all' which shows all measured params as subplots
2. update every step (if slower than 200 ms)
3. save to disk every 5 steps or 5 min to prevent data loss on crash
@peendebak @CJvanDiepen 