### PR TITLE
make the sample rate check for digitizer more general

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -1227,10 +1227,11 @@ def measuresegment_m4i(digitizer, waveform, read_ch, mV_range, Naverage=100, pro
     """
     
     drate = digitizer.sample_rate()
+    maxrate = digitizer.max_sample_rate()
     if drate == 0:
         raise Exception('sample rate of m4i is zero, please reset the digitizer')
-    if drate >= 50e6:
-        raise Exception('sample rate of m4i is >= 50 MHz, this is not supported')
+    if drate > maxrate:
+        raise Exception('sample rate of m4i is > %d MHz, this is not supported' % (maxrate//1e6))
 
     # code for offsetting the data in software
     signal_delay = getattr(digitizer, 'signal_delay', None)


### PR DESCRIPTION
The sampling rate check was hard coded to 50 MHz. Not sure why, but for example the digitizer used in 2x2 can sample up to 250 MHz. This commit uses `digitizer.max_sample_rate()` to check the maximum value allowed.
@peendebak 