### PR TITLE
fix length of path names in vector scans

### DIFF
--- a/examples/qtt_example.py
+++ b/examples/qtt_example.py
@@ -67,7 +67,7 @@ snapshotdata = station.snapshot()
 
 param_left=station.model.bottomgates[0]
 param_right=station.model.bottomgates[-1]
-scanjob = scanjob_t({'sweepdata': dict({'param': param_right, 'start': -500, 'end': 1, 'step': .8, 'wait_time': 5e-3}), 'minstrument': [keithley3.amplitude]})
+scanjob = scanjob_t({'sweepdata': dict({'param': param_right, 'start': -500, 'end': 1, 'step': .8, 'wait_time': 3e-3}), 'minstrument': [keithley3.amplitude]})
 data1d = qtt.measurements.scans.scan1D(station, scanjob, location=None, verbose=1)
 
 

--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -628,8 +628,17 @@ class scanjob_t(dict):
             self[field]['paramname'] = param.name
         else:
             if 'paramname' not in self[field]:
+                
+                def fmt(val):
+                    if isinstance(val, float):
+                        s = '%.4g' % val
+                        if not '.' in s:
+                            s += '.'
+                        return s
+                    else:
+                        return str(val)
                 self[field]['paramname'] = '_'.join(
-                        ['%s(%s)' % (key, value) for (key, value) in param.items()])
+                        ['%s(%s)' % (key, fmt(value)) for (key, value) in param.items()])
 
     def _start_end_to_range(self, scanfields=['stepdata', 'sweepdata']):
         """ Add range to stepdata and/or sweepdata in scanjob.
@@ -1517,12 +1526,13 @@ def scan2Dfast(station, scanjob, location=None, liveplotwindow=None, plotparam='
     return alldata
 
 
-def create_vectorscan(virtual_parameter, g_range=1, sweeporstepdata=None, start=0):
+def create_vectorscan(virtual_parameter, g_range=1, sweeporstepdata=None, start=0, step=None):
     """Converts the sweepdata or stepdata of a scanjob in those needed for virtual vector scans
     Inputs:
         virtual_parameter: parameter of the virtual gate which is varied
         g_range (float): scan range
         start (float): start if the scanjob data 
+        step (None or float): if not None, then add to the scanning field
     Outputs:
         sweeporstepdata (dict): sweepdata or stepdata needed in the scanjob for virtual vector scans"""
     if sweeporstepdata is None:
@@ -1534,6 +1544,8 @@ def create_vectorscan(virtual_parameter, g_range=1, sweeporstepdata=None, start=
         pp = {virtual_parameter.name: 1}
     sweeporstepdata = {'start': start, 'range': g_range,
                        'end': start + g_range, 'param': pp}
+    if step is not None:
+        sweeporstepdata['step']=step
     return sweeporstepdata
 
 


### PR DESCRIPTION
For the 8-dot we make large vectors scans. The parameter specification contains the full set of gates and coefficients formatted as `%f`. When storing the resulting datasets, the filenames become too long for windows to handle. This PR is a quick fix that solves the issues until we go to even larger scans by using a shorter formatter based on `%.3g`.

A more proper fix would be to set the `array.aray_id` field to something short, and set `array.name` to the full name that we want for labeling axis.

@lucblom @CJvanDiepen @Christian-Volk 


  