### PR TITLE
Functionality that automatically removes slow gates from the sweepparams

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -1648,7 +1648,7 @@ def create_vectorscan(virtual_parameter, g_range=1, sweeporstepdata=None, remove
         if remove_slow_gates:
             try:
                 for gate in list(pp.keys()):
-                    if station.awg.awg_gate(gate):
+                    if not station.awg.awg_gate(gate):
                         pp.pop(gate, None)
                         
             except Exception as ex:


### PR DESCRIPTION
I added functionality that automatically removes slow gates (gates not in station.awg.awg_map) from the swepparams dict in scan2Dfast, scan2Dturbo and videomode. This is useful if a virtual gate matrix including slow gates is used, but still fast measruements should be done. The fast measurement will then run but without compensation on the slow gates.