### PR TITLE
Ramps in make_pulses

### DIFF
--- a/qtt/instrument_drivers/virtual_awg.py
+++ b/qtt/instrument_drivers/virtual_awg.py
@@ -267,7 +267,10 @@ class virtual_awg(Instrument):
             voltages (list of floats): voltage levels to be applied in the sequence
             waittimes (list of floats): duration of each pulse in the sequence
             filtercutoff (float): cutoff frequency of a 1st order butterworth filter to make the pulse steps smoother
-            rampparams (dict): times (list of floats), proportions (list of length 2 tuples of floats from 0 to 1). Ramp happens at the end of each pulse.
+            rampparams (dict): the ramps cut into the end of each pulse, such that the original total length of the sequence is not affected.
+            rampparams keys:
+                times (list of floats): length of the ramp at the end of each pulse (times[i] < waittimes[i])
+                proportions (list of tuples): each tuple contains the (start,end) proportions of the ramps (e.g. (0,1) to make a ramp for the entire pulse transition voltage)
             
         Returns:
             wave_raw (array): raw data which represents the waveform

--- a/qtt/instrument_drivers/virtual_awg.py
+++ b/qtt/instrument_drivers/virtual_awg.py
@@ -289,8 +289,8 @@ class virtual_awg(Instrument):
                     raise Exception('Ramp proportions must be between 0 and 1')
             ramptimes = rampparams['times']
             rampprops = rampparams['proportions']
+            ramples = [int(x * self.AWG_clock) for x in ramptimes]
         samples = [int(x * self.AWG_clock) for x in waittimes]
-        ramples = [int(x * self.AWG_clock) for x in ramptimes]
         if mvrange is None:
             mvrange = [max(voltages), min(voltages)]
         v_wave = float((mvrange[0] - mvrange[1]) / self.ch_amp)

--- a/qtt/instrument_drivers/virtual_awg.py
+++ b/qtt/instrument_drivers/virtual_awg.py
@@ -260,25 +260,49 @@ class virtual_awg(Instrument):
 
         return wave_raw
     
-    def make_pulses(self, voltages, waittimes, filtercutoff=None, mvrange=None):
+    def make_pulses(self, voltages, waittimes, filtercutoff=None, rampparams=None, mvrange=None):
         """Make a pulse sequence with custom voltage levels and wait times at each level.
         
         Arguments:
             voltages (list of floats): voltage levels to be applied in the sequence
             waittimes (list of floats): duration of each pulse in the sequence
-            filtercutoff (float): cutoff frequency of a 1st order butterworth filter to make the pulse steps smoother 
+            filtercutoff (float): cutoff frequency of a 1st order butterworth filter to make the pulse steps smoother
+            rampparams (dict): times (list of floats), proportions (list of length 2 tuples of floats from 0 to 1). Ramp happens at the end of each pulse.
             
         Returns:
             wave_raw (array): raw data which represents the waveform
         """
         if len(waittimes) != len(voltages):
             raise Exception('Number of voltage levels must be equal to the number of wait times')
+        if rampparams is not None:
+            if (len(waittimes) != len(rampparams['times'])) or (len(waittimes) != len(rampparams['proportions'])):
+                raise Exception('Ramp parameter lists must be equal to the number of wait times')
+            if any(x > y for x, y in zip(rampparams['times'], waittimes)):
+                raise Exception('Ramp times cannot be longer than wait times')
+            for x in rampparams['proportions']:
+                if np.diff(x) < 0:
+                    raise Exception('First proportion in tuple must be larger than second')
+                if any((y > 1) or (y < 0) for y in x):
+                    raise Exception('Ramp proportions must be between 0 and 1')
+            ramptimes = rampparams['times']
+            rampprops = rampparams['proportions']
         samples = [int(x * self.AWG_clock) for x in waittimes]
+        ramples = [int(x * self.AWG_clock) for x in ramptimes]
         if mvrange is None:
             mvrange = [max(voltages), min(voltages)]
         v_wave = float((mvrange[0] - mvrange[1]) / self.ch_amp)
         v_prop = [2 * ((x - mvrange[1]) / (mvrange[0] - mvrange[1])) - 1 for x in voltages]
-        wave_raw = np.concatenate([x * v_wave * np.ones(y) for x, y in zip(v_prop, samples)])
+        if rampparams is not None:
+            wave_raw = np.array([])
+            for i, (x, y, z) in enumerate(zip(samples, ramples, rampprops)):
+                if i is not len(waittimes) - 1:
+                    v_diff = v_prop[i+1] - v_prop[i]
+                else:
+                    v_diff = v_prop[0] - v_prop[i]
+                wave_raw.append(np.concatenate([v_prop[i] * v_wave * np.ones(x-y)],
+                                               np.linspace(v_prop[i] - v_diff * z[0], v_prop[i] - v_diff * z[1], y))) 
+        else:
+            wave_raw = np.concatenate([x * v_wave * np.ones(y) for x, y in zip(v_prop, samples)])
         if filtercutoff is not None:
             b,a = scipy.signal.butter(1,0.5*filtercutoff/self.AWG_clock, btype='low', analog=False, output='ba')
             wave_raw = scipy.signal.filtfilt(b,a,wave_raw)


### PR DESCRIPTION
@eendebakpt @lucblom I'm not sure how far along you are with the pulse library, so I'll leave this up to you if you think it's worth merging or not.
The filtering wasn't giving me enough control over the adiabaticity of the pulses in `make_pulses` so I added the option to make ramps of configurable length and relative voltage distance between pulses.
The `proportions` key is not very intuitive or easy to explain in a simple way in the docs, but it was the easiest implementation I could come up with. Open to suggestions if you guys think there's a more user friendly way of doing it. 