### PR TITLE
add code_version method

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,7 +209,7 @@ Manual installation:
 ```
 
 ```
-> pip install slacker attrs pyserial redis pyvisa Polygon3 colorama pyvisa
+> pip install slacker attrs pyserial redis dulwich pyvisa Polygon3 colorama pyvisa
 ```
 
 There was a bug in qtconsole, see [qtconsole#145](https://github.com/jupyter/qtconsole/pull/145), so do

--- a/condalist.yml
+++ b/condalist.yml
@@ -95,6 +95,7 @@ dependencies:
   - jupyter-core
   - prompt-toolkit
   - apscheduler
+  - dulwich
   - pyserial
   - pyzmqrpc
   - Polygon3

--- a/develop_requirements.txt
+++ b/develop_requirements.txt
@@ -13,6 +13,7 @@ pyvisa
 slacker
 apscheduler
 spyder
+dulwich
 colorama
 attrs
 Polygon3

--- a/qtt/tools.py
+++ b/qtt/tools.py
@@ -39,6 +39,46 @@ import subprocess
 import glob
 import time
 from colorama import Fore
+import importlib
+from dulwich.repo import Repo
+
+#%%
+
+def code_version(verbose=0):
+    """ Return dictionary containing most import versions and git tags
+    
+    Args:
+        verbose (int): output level
+    Returns:
+        r (dict)
+    """
+    r={'version': {}, 'git': {}}
+   
+    for p in ['qcodes', 'qtt', 'numpy', 'scipy', 'qctoolkit']:        
+        m=importlib.import_module(p)
+        v=getattr(m, '__version__', 'none')
+        if verbose:
+            print('module %s: %s' % (p, v))
+        r['version'][p]=v
+    for p in ['qcodes', 'qtt', 'projects', 'pycqed']:        
+        m=importlib.import_module(p)
+        try:
+            f=m.__file__
+            x=os.path.split(f)[0]
+            x=os.path.join(x, '..')
+            repo=Repo(x)
+            tag=repo.head()
+            tag=tag.decode('ascii')
+        except:
+            tag='none'    
+        if verbose:
+            print('repo %s: %s' % (p, tag ))
+        r['git'][p]=tag
+
+    return r
+
+def test_code_version():
+    _=code_version()
 
 #%% Jupyter kernel tools
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(name='qtt',
       packages=find_packages(),
       #requires=['numpy', 'matplotlib', 'scipy', 'qcodes', 'pandas', 'attrs', 'qtpy', 'slacker', 'nose', 'hickle'],
       install_requires=[
-          'matplotlib', 'pandas', 'attrs', 'qtpy', 'nose', 'slacker', 'hickle', 'pyzmqrpc',
+          'matplotlib', 'pandas', 'attrs', 'dulwich', 'qtpy', 'nose', 'slacker', 'hickle', 'pyzmqrpc',
           'numpy>=1.10',
           'IPython>=0.1',
           'qcodes>=0.1.5',


### PR DESCRIPTION
@lucblom Only a simple version, but it serves for the research group. If PR is fine, then I will add the output of `code_version` to the different measurement functions. Overhead of the function is low: measured to be 0.03 seconds on my system