### PR TITLE
fix test and docs for RTS

### DIFF
--- a/qtt/algorithms/random_telegraph_signal.py
+++ b/qtt/algorithms/random_telegraph_signal.py
@@ -161,6 +161,13 @@ def tunnelrates_RTS(data, samplerate = None, min_sep = 2.0, max_sep = 7.0, min_d
     durations_dn_min_duration = durations_dn_idx > min_duration
     durations_dn = durations_dn_idx[durations_dn_min_duration]
     
+        
+    if len(durations_up) < 1:
+        raise FittingException('All durations_up are shorter than the minimal duration.')
+        
+    if len(durations_dn) < 1:
+        raise FittingException('All durations_dn are shorter than the minimal duration.')
+    
     # calculating durations in seconds
     durations_dn= durations_dn/samplerate
     durations_up= durations_up/samplerate


### PR DESCRIPTION
@fvanriggelen The test failed because the peak separation has too far (> 7 std in the test data). This has been fixed. However, the test sometimes fails (not always since we use random data) because a negative split is generated (failed fitting of the gaussians I guess).

Can you run the tests multiple times to see whether it fails for you as well. If it fails, can you investigate?