### PR TITLE
by default start sawtooth at zero for 1D scans

### DIFF
--- a/qtt/measurements/videomode.py
+++ b/qtt/measurements/videomode.py
@@ -137,7 +137,8 @@ class VideoMode:
         self.diff_dir = diff_dir
         self.datalock = threading.Lock()
         self.datafunction_result = None
-
+        self.update_sleep = 1e-5
+        
         # parse instrument
         if 'fpga' in station.components:
             self.sampling_frequency = station.fpga.sampling_frequency
@@ -286,7 +287,7 @@ class VideoMode:
 
         if self.fps.framerate() < 10:
             time.sleep(0.1)
-        time.sleep(0.00001)
+        time.sleep(self.update_sleep)
 
     def is_running(self):
         return self.timer.isActive()


### PR DESCRIPTION
The scan1Dfast and videomode use sawtooth shape functions for scanning. These start the the minimum value of the sawtooth and not at zero. The Tektronix 5014 devices (and perhaps other AWGs) have an issue with this: if we do not start at zero then charge is accumulated in the bias tees and it takes the system a couple of seconds to settle. (this can be best seen when starting the videomode for a 1D trace).

There are three possible solutions for this:

1. Buy a new AWG 
2. Create a sequence that starts with a short zero segment and then starts a sawtooth that repeats
3. Make a waveform that starts at zero (e.g. periodically shift the sawtooth we used earlier)

Option 1. is expensive. Option 2. is possible, but requires more programming on the AWG. 

In this PR I implemented the third option for the `sweep_gate` function of the AWG. I did test with the videomode and it really helps. Not yet done: `sweep_gate_virt` and the 2D variations of the scans.

@lucblom @jpdehollain @CJvanDiepen @fvanriggelen @Christian-Volk  @gzheng29 

Note: when doing PSB or other readout type measurements: if your pulse sequence does not start with zero (on all AWG channels) you need to wait some time (couple of seconds) before reading out data with the digitizer. If you are not yet doing this: modify your code to start at zero _or_ wait before reading data _or_ talk to me to see how it affects your system.


