### PR TITLE
Extra pulsing functionality to fast scans

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -467,11 +467,28 @@ def scan1Dfast(station, scanjob, location=None, liveplotwindow=None, delete=True
             sweeprange = (sweepdata['end'] - sweepdata['start'])
             sweepgate_value = (sweepdata['start'] + sweepdata['end']) / 2
             gates.set(sweepdata['param'], float(sweepgate_value))
-        waveform, sweep_info = station.awg.sweep_gate(sweepdata['param'], sweeprange, period, delete=delete)
+        if 'pulsedata' in scanjob:
+            waveform, sweep_info = station.awg.sweepandpulse_gate(
+                {'gate': sweepdata['param'].name,
+                    'sweeprange': sweeprange, 'period': period},
+                scanjob['pulsedata'])
+        else:
+            waveform, sweep_info = station.awg.sweep_gate(sweepdata['param'], sweeprange, period, delete=delete)
     else:
         sweeprange = sweepdata['range']
-        waveform, sweep_info = station.awg.sweep_gate_virt(
-            fast_sweep_gates, sweeprange, period, delete=delete)
+        if 'pulsedata' in scanjob:
+            sg = []
+            for g, v in fast_sweep_gates.items():
+                if v != 0:
+                    sg.append(g)
+            if len(sg) > 1:
+                raise(Exception('AWG pulses does not yet support virtual gates'))
+            waveform, sweep_info = station.awg.sweepandpulse_gate(
+                {'gate':sg[0], 'sweeprange':sweeprange, 'period':period},
+                scanjob['pulsedata'])
+        else:
+            waveform, sweep_info = station.awg.sweep_gate_virt(
+                    fast_sweep_gates, sweeprange, period, delete=delete)
 
     qtt.time.sleep(wait_time_startscan)
 
@@ -1564,8 +1581,19 @@ def scan2Dfast(station, scanjob, location=None, liveplotwindow=None, plotparam='
 
     if scanjob['scantype'] == 'scan2Dfastvec':
         scanjob._parse_2Dvec()
-        waveform, sweep_info = station.awg.sweep_gate_virt(
-            fast_sweep_gates, sweepdata['range'], period)
+        if 'pulsedata' in scanjob:
+            sg = []
+            for g, v in fast_sweep_gates.items():
+                if v != 0:
+                    sg.append(g)
+            if len(sg) > 1:
+                raise(Exception('AWG pulses does not yet support virtual gates'))
+            waveform, sweep_info = station.awg.sweepandpulse_gate(
+                {'gate':sg[0], 'sweeprange':sweepdata['range'], 'period':period},
+                scanjob['pulsedata'])
+        else:
+            waveform, sweep_info = station.awg.sweep_gate_virt(
+                fast_sweep_gates, sweepdata['range'], period)
     else:
         if 'range' in sweepdata:
             sweeprange = sweepdata['range']


### PR DESCRIPTION
- Added the pulsing option to scan1Dfast

- For both scan1Dfast and scan2Dfast, I added to the pulsing option, support for a vector gate, although it still does not support virtual gates. (e.g. the input vector gate can only have a single gate, {P1:1}. This is useful because sometimes we run scans with a single gate in x (where the pulsing can be applied), and a virtual gate in y (where we're stepping with DACs).