### PR TITLE
one line fix tools.py

### DIFF
--- a/qtt/tools.py
+++ b/qtt/tools.py
@@ -13,7 +13,7 @@ import tempfile
 from itertools import chain
 import scipy.ndimage as ndimage
 from functools import wraps
-from pip import get_installed_distributions
+
 try:
     from dulwich.repo import Repo, NotGitRepository
     from dulwich import porcelain


### PR DESCRIPTION
the import from pip gives an error on my system (pip 10.1) and doesn't seem to be used anyway. As it's imported in qtt\__init__ it breaks everything. Taking out that line fixes the problem for me.

Can you check, @lucblom or @peendebak 