### PR TITLE
dataviewer: add meta tabs

### DIFF
--- a/qtt/gui/dataviewer.py
+++ b/qtt/gui/dataviewer.py
@@ -367,6 +367,8 @@ class DataViewer(QtWidgets.QWidget):
         try:
             logging.debug('DataViewer: load tag %s' % tag)
             data = self.loadData(filename, tag)
+            if not data:
+                raise ValueError('File invalid (%s) ...' % filename)
             self.dataset = data
             self.updateMetaTabs()
 


### PR DESCRIPTION
Added tabs to the metadata treeview to show relevant subsets (eg gates, instruments) directly.

@lucblom 