### PR TITLE
Moved qctoolkit references to qupulse.

### DIFF
--- a/develop_requirements.txt
+++ b/develop_requirements.txt
@@ -20,7 +20,7 @@ pyzmqrpc
 pyqtgraph
 PyQt5
 qcodes
--e git+https://github.com/qutech/qc-toolkit.git@12af2dff0506c42e721b65696126849f23d7a4ce#egg=qctoolkit
+git+https://github.com/qutech/qupulse#egg=qupulse
 redis
 scipy >= 0.18
 scikit-image

--- a/qtt/instrument_drivers/virtualAwg/__init__.py
+++ b/qtt/instrument_drivers/virtualAwg/__init__.py
@@ -1,0 +1,3 @@
+import warnings
+
+warnings.filterwarnings('ignore', category=UserWarning, message="gmpy2 not found.*")

--- a/qtt/instrument_drivers/virtualAwg/serializer.py
+++ b/qtt/instrument_drivers/virtualAwg/serializer.py
@@ -1,4 +1,4 @@
-from qctoolkit.serialization import StorageBackend
+from qupulse.serialization import StorageBackend
 
 
 class StringBackend(StorageBackend):

--- a/qtt/instrument_drivers/virtualAwg/templates.py
+++ b/qtt/instrument_drivers/virtualAwg/templates.py
@@ -1,17 +1,17 @@
-from qctoolkit.pulses import TablePT
+from qupulse.pulses import TablePT
 
 
 class DataTypes:
     """ The possible data types for the pulse creation."""
     RAW_DATA = 'rawdata'
-    QC_TOOLKIT = 'qctoolkit'
+    QU_PULSE = 'qupulse'
 
 
 class Templates:
 
     @staticmethod
     def square(name):
-        """ Creates a block wave QC toolkit template for sequencing.
+        """ Creates a block wave qupulse template for sequencing.
 
         Args:
             name (str): The user defined name of the sequence.
@@ -24,7 +24,7 @@ class Templates:
 
     @staticmethod
     def sawtooth(name):
-        """ Creates a sawtooth QC toolkit template for sequencing.
+        """ Creates a sawtooth qupulse template for sequencing.
 
         Args:
             name (str): The user defined name of the sequence.
@@ -38,7 +38,7 @@ class Templates:
 
     @staticmethod
     def hold(name):
-        """Creates a DC offset QC toolkit template for sequencing.
+        """Creates a DC offset qupulse template for sequencing.
 
         Args:
             name (str): The user defined name of the sequence.
@@ -50,7 +50,7 @@ class Templates:
 
     @staticmethod
     def marker(name):
-        """Creates a TTL pulse QC toolkit template for sequencing.
+        """Creates a TTL pulse qupulse template for sequencing.
 
         Args:
             name (str): The user defined name of the sequence.

--- a/qtt/utilities/tools.py
+++ b/qtt/utilities/tools.py
@@ -120,7 +120,7 @@ def get_python_version(verbose=0):
 
 
 def code_version(repository_names=None, package_names=None, get_dirty_status=False, verbose=0):
-    """ Returns the python version, module version for; numpy, scipy, qctoolkit
+    """ Returns the python version, module version for; numpy, scipy, qupulse
         and the git guid and dirty status for; qcodes, qtt, spin-projects and pycqed,
         if present on the machine. NOTE: currently the dirty status is not working
         correctly due to a bug in dulwich...
@@ -135,7 +135,7 @@ def code_version(repository_names=None, package_names=None, get_dirty_status=Fal
         status (dict): python, modules and git repos status.
     """
     _default_git_versions = ['qcodes', 'qtt', 'projects', 'pycqed']
-    _default_module_versions = ['numpy', 'scipy', 'qctoolkit', 'h5py', 'skimage']
+    _default_module_versions = ['numpy', 'scipy', 'qupulse', 'h5py', 'skimage']
     if not repository_names:
         repository_names = _default_git_versions
     if not package_names:
@@ -154,13 +154,15 @@ def code_version(repository_names=None, package_names=None, get_dirty_status=Fal
 
 
 def test_python_code_modules_and_versions():
-    _ = get_python_version()
-    _ = get_module_versions(['numpy'])
-    _ = get_git_versions(['qtt'])
-    c = code_version()
-    assert('python' in c)
-    assert('timestamp' in c)
-    assert('system' in c)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning, message="qupulse")
+        _ = get_python_version()
+        _ = get_module_versions(['numpy'])
+        _ = get_git_versions(['qtt'])
+        c = code_version()
+        assert('python' in c)
+        assert('timestamp' in c)
+        assert('system' in c)
 
 # %% Jupyter kernel tools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyqtgraph
 pyzmqrpc
 PyQt5
 qtpy
-qupulse
+git+https://github.com/qutech/qupulse#egg=qupulse
 sympy
 slacker
 scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyqtgraph
 pyzmqrpc
 PyQt5
 qtpy
--e git+https://github.com/qutech/qc-toolkit.git@12af2dff0506c42e721b65696126849f23d7a4ce#egg=qupulse
+qupulse
 sympy
 slacker
 scikit-image


### PR DESCRIPTION
@peendebak 

Should resolve the issue #439. Currently the master branch of qupulse gives a warning when not using `fractions.Fraction` as [you](https://github.com/qutech/qupulse/issues/375) mentioned.