### PR TITLE
allow recent versions of numpy

### DIFF
--- a/condalist.yml
+++ b/condalist.yml
@@ -40,7 +40,7 @@ dependencies:
 - networkx
 - nose
 - notebook
-- numpy==1.13
+- numpy
 - numpydoc
 - olefile
 - openssl


### PR DESCRIPTION
In QCoDeS numpy >= 1.14 can be used (see https://github.com/QCoDeS/Qcodes/pull/1120).  Fixes #466

@lucblom 