### PR TITLE
Fixing the virtual AWG

### DIFF
--- a/qtt/instrument_drivers/virtualAwg/awgs/Tektronix5014C.py
+++ b/qtt/instrument_drivers/virtualAwg/awgs/Tektronix5014C.py
@@ -95,7 +95,7 @@ class Tektronix5014C_AWG(AwgCommon):
                 data_count = len(data_array)
                 waveform_data[name] = [np.zeros(data_count), np.zeros(data_count), np.zeros(data_count)]
                 channel_data.setdefault(channel_nr, []).append(name)
-            index = marker_nr[-1] if len(marker_nr) > 1 else 0
+            index = marker_nr[-1] if len(marker_nr) >= 1 else 0
             waveform_data[name][index] = data_array
         if reload:
             self._upload_waveforms(list(waveform_data.keys()), list(waveform_data.values()))

--- a/qtt/instrument_drivers/virtualAwg/sequencer.py
+++ b/qtt/instrument_drivers/virtualAwg/sequencer.py
@@ -75,11 +75,11 @@ class Sequencer:
         """
         if uptime <= 0 or offset < 0:
             raise ValueError('Invalid argument value (uptime <= 0 or offset < 0)!')
-        if uptime + offset > 1:
+        if uptime + offset > period:
             raise ValueError('Invalid argument value (uptime + offset > period)!')
-        input_variables = {'period': period*Sequencer.__sec_to_ns,
-                           'uptime': period*uptime*Sequencer.__sec_to_ns,
-                           'offset': period*offset*Sequencer.__sec_to_ns}
+        input_variables = {'period': period * Sequencer.__sec_to_ns,
+                           'uptime': uptime * Sequencer.__sec_to_ns,
+                           'offset': offset * Sequencer.__sec_to_ns}
         sequence_data = (Templates.marker(name), input_variables)
         return {'name': name, 'wave': SequencePT(*((sequence_data,)*repetitions)),
                 'type': DataTypes.QU_PULSE, 'uptime': uptime, 'offset': offset}
@@ -292,5 +292,3 @@ def test_serializer():
         amplitude = 1.5
         sawtooth = Sequencer.make_sawtooth_wave(amplitude, period)
         Sequencer.serialize(sawtooth)
-
-    

--- a/qtt/instrument_drivers/virtualAwg/virtual_awg.py
+++ b/qtt/instrument_drivers/virtualAwg/virtual_awg.py
@@ -101,8 +101,9 @@ class VirtualAwg(Instrument):
             amplitude = rel_amplitude * sweep_range
             sequences[gate_name] = Sequencer.make_square_wave(amplitude, period)
         sweep_data = self.sequence_gates(sequences, do_upload)
-        return sweep_data.update({'sweeprange': sweep_range, 'period': period,
-                                  'markerdelay': self.digitizer_marker_delay()})
+        sweep_data.update({'sweeprange': sweep_range, 'period': period,
+                           'markerdelay': self.digitizer_marker_delay()})
+        return sweep_data
 
     def sweep_gates(self, gates, sweep_range, period, width=0.95, do_upload=True):
         """ Sweep a set of gates with a sawtooth waveform.

--- a/qtt/instrument_drivers/virtualAwg/virtual_awg.py
+++ b/qtt/instrument_drivers/virtualAwg/virtual_awg.py
@@ -10,7 +10,7 @@ try:
     from qtt.instrument_drivers.virtualAwg.awgs.KeysightM3202A import KeysightM3202A_AWG
 except:
     logging.debug('could not load KeysightM3202A driver')
-    KeysightM3202A_AWG=None
+    KeysightM3202A_AWG = None
 from qtt.instrument_drivers.virtualAwg.awgs.ZurichInstrumentsHDAWG8 import ZurichInstruments_HDAWG8
 
 
@@ -80,7 +80,7 @@ class VirtualAwg(Instrument):
     def update_setting(self, awg_number, setting, value):
         if awg_number not in self.__awg_range:
             raise VirtualAwgError('Invalid AWG number {}!'.format(awg_number))
-        self.awgs[awg_number].update_setting(setting, value)
+        self.awgs[awg_number].change_setting(setting, value)
 
     def are_awg_gates(self, gate_names):
         if gate_names is None:

--- a/qtt/instrument_drivers/virtualAwg/virtual_awg.py
+++ b/qtt/instrument_drivers/virtualAwg/virtual_awg.py
@@ -182,7 +182,7 @@ class VirtualAwg(Instrument):
                 if awg_number != number:
                     continue
                 awg_to_plunger = self.__hardware.parameters['awg_to_{}'.format(gate_name)].get()
-                scaling_ratio = 2 * VirtualAwg.__volt_to_millivolt / awg_to_plunger / vpp_amplitude
+                scaling_ratio = 2 * VirtualAwg.__volt_to_millivolt * awg_to_plunger / vpp_amplitude
 
                 sample_data = Sequencer.get_data(sequence, sampling_rate)
                 sequence_data = sample_data if marker_number else sample_data * scaling_ratio


### PR DESCRIPTION
- Apply marker delay in seconds instead of using a percentage of the period.
- Changed the AWG to plunger conversion factor.
- Fixed return value of the pulse gates.