### PR TITLE
Rename the default measure_names in scan2Dfast

### DIFF
--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -1989,7 +1989,7 @@ def plotData(alldata, diff_dir=None, fig=1):
 # %%
 
 
-def scan2Dturbo(station, scanjob, location=None, liveplotwindow=None, plotparam='measured', delete=True, verbose=1):
+def scan2Dturbo(station, scanjob, location=None, liveplotwindow=None, delete=True, verbose=1):
     """Perform a very fast 2d scan by varying two physical gates with the AWG.
 
     The function assumes the station contains an FPGA with readFPGA function. 
@@ -2093,8 +2093,6 @@ def scan2Dturbo(station, scanjob, location=None, liveplotwindow=None, plotparam=
         measure_names = ['measured']
     else:
         measure_names = ['READOUT_ch%d' % c for c in read_ch]
-        if plotparam == 'measured':
-            plotparam = measure_names[0]
 
     if scanjob['scantype'] == 'scan2Dturbo':
         alldata, _ = makeDataset_sweep_2D(data, gates, sweepgates, sweepranges, measure_names=measure_names,

--- a/qtt/measurements/scans.py
+++ b/qtt/measurements/scans.py
@@ -2092,7 +2092,9 @@ def scan2Dturbo(station, scanjob, location=None, liveplotwindow=None, plotparam=
     if len(read_ch) == 1:
         measure_names = ['measured']
     else:
-        measure_names = ['FPGA_ch%d' % c for c in read_ch]
+        measure_names = ['READOUT_ch%d' % c for c in read_ch]
+        if plotparam == 'measured':
+            plotparam = measure_names[0]
 
     if scanjob['scantype'] == 'scan2Dturbo':
         alldata, _ = makeDataset_sweep_2D(data, gates, sweepgates, sweepranges, measure_names=measure_names,


### PR DESCRIPTION
Rename from ```FPGA_ch...``` to ```READOUT_ch...```.