### PR TITLE
Added code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-cache: pip
 
 matrix:
   include:
@@ -14,6 +13,7 @@ matrix:
     env: FULL_INSTALL=1
 
 install:
+    - pip install qcodes
     - pip install -r requirements.txt
     - pip install opencv-python coveralls
     - if [[ "$FULL_INSTALL" == "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ install:
     # doing a normal python setup.py install gives issues with pytest
     - python setup.py develop
 
+    # from https://code-maven.com/coverall-with-python-minimal-setup
+    - pip install pytest pytest-cov coveralls
+    
 # for xvfb details see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
 
 script: 
@@ -35,3 +38,6 @@ script:
       jupyter --version;
       source docs/notebooks/run_notebooks.sh;
       fi
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,41 +3,37 @@ cache: pip
 
 matrix:
   include:
-  - name: "Minimal install"
-    python: "3.6"
-    env: DO_NOTEBOOKS=0 FULL_INSTALL=0
-  - name: "Full install"
-    python: "3.6"
-    env: DO_NOTEBOOKS=1 FULL_INSTALL=1
+  - name: Minimal installation
+    python: 3.6
+    sudo: true
+    dist: xenial
+
+  - name: Full installation
+    python: 3.6
+    dist: xenial
+    env: FULL_INSTALL=1
 
 install:
-    - if [ "$FULL_INSTALL" == "1" ]; then
-      echo "Full installation! DO_NOTEBOOKS=$DO_NOTEBOOKS";
-      fi
     - pip install -r requirements.txt
-    - if [ "$FULL_INSTALL" == "1" ]; then
-      pip install -r develop_requirements.txt;
+    - pip install opencv-python coveralls
+    - if [[ "$FULL_INSTALL" == "1" ]]; then
+        echo "Full Installation";
+        pip install -r develop_requirements.txt;
       fi
-    # opencv is needed for most of the tests right now
-    - pip install opencv-python;
-    # doing a normal python setup.py install gives issues with pytest
     - python setup.py develop
 
-    # from https://code-maven.com/coverall-with-python-minimal-setup
-    - pip install pytest pytest-cov coveralls
-    
-# for xvfb details see https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
-
-script: 
+script:
     - ls
     - pytest --version
-    - pytest -v
-    #- xvfb-run -a pytest 
-    # run notebooks
-    - if [ $FULL_INSTALL == "1" ]; then
-      jupyter --version;
-      source docs/notebooks/run_notebooks.sh;
+    - coverage run --source="./qtt" --omit="*/test_*"  -m pytest
+    - if [[ "$FULL_INSTALL" == "1" ]]; then
+        jupyter --version;
+        source docs/notebooks/run_notebooks.sh;
       fi
 
 after_success:
   - coveralls
+    
+
+# - xvfb-run -a pytest
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui

--- a/develop_requirements.txt
+++ b/develop_requirements.txt
@@ -7,8 +7,8 @@ certifi
 colorama
 hickle>= 3.1
 jupyter
-numpy >= 1.13
-matplotlib >= 2.1
+numpy>=1.13
+matplotlib>=2.1
 pandas
 qtpy
 h5py
@@ -20,9 +20,9 @@ pyzmqrpc
 pyqtgraph
 PyQt5
 qcodes
-git+https://github.com/qutech/qupulse#egg=qupulse
+qupulse
 redis
-scipy >= 0.18
+scipy>=0.18
 scikit-image
 scikit-learn
 slacker

--- a/qtt/pgeometry.py
+++ b/qtt/pgeometry.py
@@ -2321,11 +2321,3 @@ if __name__ == '__main__':
     test_geometry()
     test_intersect2lines()
 
-# %% Run tests from documentation
-if __name__ == "__main__":
-    """ Dummy main for testing
-    """
-
-    import unittest
-    #testcase = unittest.FunctionTestCase(test_intersect2lines)
-    unittest.main()

--- a/qtt/tests/test_pgeometry.py
+++ b/qtt/tests/test_pgeometry.py
@@ -1,0 +1,29 @@
+import unittest
+import numpy as np
+
+import qtt.pgeometry as pgeometry
+
+
+class TestGeometryOperations(unittest.TestCase):
+
+    def test_pg_rotx(self):
+        I = pgeometry.pg_rotx(90).dot(pgeometry.pg_rotx(-90))
+        np.testing.assert_almost_equal(I, np.eye(3))
+
+        for phi in [0, .1, np.pi, 4]:
+            Rx = pgeometry.pg_rotx(phi)
+            self.assertAlmostEqual(Rx[1, 1], np.cos(phi))
+            self.assertAlmostEqual(Rx[2, 1], np.sin(phi))
+
+    def test_pg_rotation2H(self):
+        R = pgeometry.pg_rotx(.12)
+        H = pgeometry.pg_rotation2H(R)
+        np.testing.assert_almost_equal(R, H[:3, :3])
+
+
+if __name__ == "__main__":
+    """ Dummy main for testing
+    """
+
+    import unittest
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 apscheduler
-attrs >= 18.2.0
+attrs>=18.2.0
 colorama
 coverage
 dulwich
-hickle >= 3.1
-numpy
-matplotlib >= 2.1
+hickle>=3.1
+numpy>=1.13
+matplotlib>=2.1
 pandas
 Polygon3
 pyqtgraph
@@ -13,9 +13,9 @@ pyzmqrpc
 PyQt5
 qcodes
 qtpy
-git+https://github.com/qutech/qupulse#egg=qupulse
+qupulse
 sympy
 slacker
 scikit-image
-scipy >= 0.18
+scipy>=0.18
 tables


### PR DESCRIPTION
@peendebak 

- I added the coverage. Other analysis tools require some investigation, because they are not always free (>4 developers).

- I removed the pip cache statement. We would like to see how qtt installs from scratch without caching old pip-package installations.

- The current PyPi QCoDeS requires numpy < 1.14 where we also have Polygon3 raising errors when numpy is <1.14... How to solve this in a robust manner? Installing QCoDeS directly from the git master maybe?