### PR TITLE
add calibration exception

### DIFF
--- a/src/qtt/algorithms/coulomb.py
+++ b/src/qtt/algorithms/coulomb.py
@@ -586,6 +586,15 @@ def peakdataOrientation(x, y):
     return x, y
 
 
+def sort_peaks_inplace(peaks):
+    """ Sort a list of peaks according to the score field """
+    peaks.sort(key=lambda x: -x['score'])
+
+def sort_peaks(peaks):
+    """ Sort a list of peaks according to the score field """
+    peaks_sorted = sorted(peaks, key=lambda p: -p['score'])
+    return peaks_sorted
+
 def coulombPeaks(x_data, y_data, verbose=1, fig=None, plothalf=False, sampling_rate=None, parameters=None):
     """ Detects the Coulumb peaks in a 1D scan.
 
@@ -609,7 +618,7 @@ def coulombPeaks(x_data, y_data, verbose=1, fig=None, plothalf=False, sampling_r
     goodpeaks = filterPeaks(x, y, peaks, verbose=verbose)
 
     peakScores(goodpeaks, x, y, verbose=verbose)
-    goodpeaks.sort(key=lambda x: -x['score'])
+    sort_peaks_inplace(goodpeaks)
 
     if fig:
         plotPeaks(x, y, goodpeaks, fig=fig, plotLabels=True, plothalf=plothalf)
@@ -696,7 +705,7 @@ def findBestSlope(x, y, minimal_derivative=None, fig=None, verbose=1):
         slope['phalfl'] = phl
         slope['phalf0'] = int(phl)
 
-        slope['length'] = x - x[pbottom]
+        #slope['length'] = x - x[pbottom]
         slope['height'] = y[p] - y[pbottom]
         slope['valid'] = (slope['height'] / H) > .2
         slope['type'] = 'slope'
@@ -798,5 +807,5 @@ def filterOverlappingPeaks(goodpeaks, threshold=.6, verbose=0):
     if verbose:
         print('filterOverlappingPeaks: %d -> %d peaks' % (len(pp), len(gidx)))
     pp = [pp[jj] for jj in gidx]
-    pp = sorted(pp, key=lambda p: p['score'])
+    pp = sort_peaks(pp)
     return pp

--- a/src/qtt/exceptions.py
+++ b/src/qtt/exceptions.py
@@ -2,9 +2,6 @@ class MissingOptionalPackageWarning(UserWarning, ValueError):
     """ An optional package is missing """
     pass
 
-# %%
-
-
 class PackageVersionWarning(UserWarning):
     """ An package has the incorrect version """
     pass

--- a/src/qtt/exceptions.py
+++ b/src/qtt/exceptions.py
@@ -8,3 +8,8 @@ class MissingOptionalPackageWarning(UserWarning, ValueError):
 class PackageVersionWarning(UserWarning):
     """ An package has the incorrect version """
     pass
+
+
+class CalibrationException(BaseException):
+    """ Exception thrown for a bad calibration """
+    pass

--- a/src/qtt/structures.py
+++ b/src/qtt/structures.py
@@ -106,8 +106,7 @@ def _scanlabel(ds):
 @freezeclass
 class sensingdot_t:
 
-    def __init__(self, gate_names, gate_values=None, station=None, index=None, minstrument=None, fpga_ch=None,
-                 virt_gates=None):
+    def __init__(self, gate_names, gate_values=None, station=None, index=None, minstrument=None, virt_gates=None):
         """ Class representing a sensing dot 
 
         We assume the sensing dot can be controlled by two barrier gates and a single plunger gate.
@@ -130,6 +129,7 @@ class sensingdot_t:
         self.sdval = gate_values
         self.targetvalue = np.NaN
 
+        self._selected_peak =  None
         self._detune_axis = np.array([1, -1])
         self._detune_axis = self._detune_axis / np.linalg.norm(self._detune_axis)
         self._debug = {}  # store debug data
@@ -144,16 +144,13 @@ class sensingdot_t:
 
         self.data = {}
 
-        if fpga_ch is None:
-            self.fpga_ch = None
-        else:
-            raise Exception('do not use fpga_ch argument, use minstrument instead')
-
         # values for measurement
         if index is not None:
             self.valuefunc = station.components[
                 'keithley%d' % index].amplitude.get
-
+        else:
+            self.valuefunc=None
+            
     def __repr__(self):
         return 'sd gates: %s, %s, %s' % (self.gg[0], self.gg[1], self.gg[2])
 
@@ -462,7 +459,9 @@ class sensingdot_t:
         if len(goodpeaks) > 0:
             self.sdval[1] = float(goodpeaks[0]['xhalfl'])
             self.targetvalue = float(goodpeaks[0]['yhalfl'])
+            self._selected_peak = goodpeaks[0]
         else:
+            self._selected_peak = None
             raise qtt.exceptions.CalibrationException('fastTune: could not find good peak')
 
         if self.verbose:

--- a/src/qtt/structures.py
+++ b/src/qtt/structures.py
@@ -463,7 +463,7 @@ class sensingdot_t:
             self.sdval[1] = float(goodpeaks[0]['xhalfl'])
             self.targetvalue = float(goodpeaks[0]['yhalfl'])
         else:
-            print('autoTune: could not find good peak, may need to adjust mirror factor')
+            raise qtt.exceptions.CalibrationException('fastTune: could not find good peak')
 
         if self.verbose:
             print(

--- a/src/qtt/structures.py
+++ b/src/qtt/structures.py
@@ -150,7 +150,7 @@ class sensingdot_t:
                 'keithley%d' % index].amplitude.get
         else:
             self.valuefunc=None
-            
+
     def __repr__(self):
         return 'sd gates: %s, %s, %s' % (self.gg[0], self.gg[1], self.gg[2])
 

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -1,14 +1,14 @@
 import unittest
 import qtt.exceptions
 
+
 class TestExceptions(unittest.TestCase):
 
     def test_calibration_exception(self):
-        self.assertIsInstance(qtt.exceptions.CalibrationException, BaseException)
+        self.assertTrue(issubclass(qtt.exceptions.CalibrationException, BaseException))
 
     def test_PackageVersionWarning(self):
-        self.assertIsInstance(qtt.exceptions.PackageVersionWarning, UserWarning)
+        self.assertTrue(issubclass(qtt.exceptions.PackageVersionWarning, UserWarning))
 
     def test_MissingOptionalPackageWarning(self):
-        self.assertIsInstance(qtt.exceptions.MissingOptionalPackageWarning, UserWarning)
-
+        self.assertTrue(issubclass(qtt.exceptions.MissingOptionalPackageWarning, UserWarning))

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -1,0 +1,14 @@
+import unittest
+import qtt.exceptions
+
+class TestExceptions(unittest.TestCase):
+
+    def test_calibration_exception(self):
+        self.assertIsInstance(qtt.exceptions.CalibrationException, BaseException)
+
+    def test_PackageVersionWarning(self):
+        self.assertIsInstance(qtt.exceptions.PackageVersionWarning, UserWarning)
+
+    def test_MissingOptionalPackageWarning(self):
+        self.assertIsInstance(qtt.exceptions.MissingOptionalPackageWarning, UserWarning)
+    

--- a/src/tests/test_exceptions.py
+++ b/src/tests/test_exceptions.py
@@ -11,4 +11,4 @@ class TestExceptions(unittest.TestCase):
 
     def test_MissingOptionalPackageWarning(self):
         self.assertIsInstance(qtt.exceptions.MissingOptionalPackageWarning, UserWarning)
-    
+


### PR DESCRIPTION
The `CalibrationException` is for bad calibrations (e.g. failed fitting, result out of specification).