### PR TITLE
[OP-57] fixes OP-40 backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added scope reader for the Zurich Instruments UHFLI. (#554, #980).
 
 ### Changed
+- makeDataSetxxx methods generic functionality split off. Added a warning for data shape differences (#598, #602). 
 - Allow plotCallback to operate on datetime axis (#584).
 - VirtualDAC now has an option to set gate_map and instruments on VirtualDAC (#583).
 - All unittests are moved to a tests folder (#574).

--- a/src/qtt/data.py
+++ b/src/qtt/data.py
@@ -1,6 +1,7 @@
+""" Utilities to work with data and datasets """
+
 from typing import Optional
 from functools import wraps
-""" Utilities to work with data and datasets """
 
 import numpy as np
 import scipy
@@ -193,7 +194,6 @@ def load_dataset(location, io=None, verbose=0):
                 logging.info('load_data: location %s: failed for formatter %d: %s' % (location, ii, hformatter))
                 if verbose:
                     print(ex)
-                pass
             finally:
                 if data is not None:
                     if isinstance(hformatter, GNUPlotFormat):

--- a/src/qtt/data.py
+++ b/src/qtt/data.py
@@ -1374,15 +1374,18 @@ def compare_dataset_metadata(dataset1, dataset2, metakey='allgatevalues', verbos
         metakey (str): key in the DataSet metadata to compare
     """
     if (metakey not in dataset1.metadata) or (metakey not in dataset2.metadata):
-        print('key %s not in dataset metadata' % metakey)
+        if verbose:
+            print('key %s not in dataset metadata' % metakey)
         return
     if metakey == 'allgatevalues':
         for ikey, value1 in dataset1.metadata[metakey].items():
             if ikey in dataset2.metadata[metakey]:
                 value2 = dataset2.metadata[metakey][ikey]
                 if value1 != value2:
-                    print('Gate %s from %.1f to %.1f' % (ikey, value1, value2))
+                    if verbose:
+                        print('Gate %s from %.1f to %.1f' % (ikey, value1, value2))
             else:
-                print('Gate %s not in second dataset' % ikey)
+                if verbose:
+                    print('Gate %s not in second dataset' % ikey)
     else:
         raise Exception('metadata key not yet supported')

--- a/src/qtt/structures.py
+++ b/src/qtt/structures.py
@@ -129,7 +129,7 @@ class sensingdot_t:
         self.sdval = gate_values
         self.targetvalue = np.NaN
 
-        self._selected_peak =  None
+        self._selected_peak = None
         self._detune_axis = np.array([1, -1])
         self._detune_axis = self._detune_axis / np.linalg.norm(self._detune_axis)
         self._debug = {}  # store debug data
@@ -149,14 +149,15 @@ class sensingdot_t:
             self.valuefunc = station.components[
                 'keithley%d' % index].amplitude.get
         else:
-            self.valuefunc=None
+            self.valuefunc = None
 
     def __repr__(self):
         return 'sd gates: %s, %s, %s' % (self.gg[0], self.gg[1], self.gg[2])
 
     def __getstate__(self):
         """ Override to make the object pickable."""
-        print('sensingdot_t: __getstate__')
+        if self.verbose:
+            print('sensingdot_t: __getstate__')
         import copy
         d = copy.copy(self.__dict__)
         for name in ['station', 'valuefunc']:
@@ -207,7 +208,8 @@ class sensingdot_t:
 
     def scan1D(sd, outputdir=None, step=-2., max_wait_time=.75, scanrange=300):
         """ Make 1D-scan of the sensing dot."""
-        print('### sensing dot scan')
+        if sd.verbose:
+            print('### sensing dot scan')
         minstrument = sd.minstrument
         if sd.index is not None:
             minstrument = [sd.index]
@@ -235,8 +237,9 @@ class sensingdot_t:
         scanjob1['compensateGates'] = []
         scanjob1['gate_values_corners'] = [[]]
 
-        print('sensingdot_t: scan1D: gate %s, wait_time %.3f' % (sd.gg[1], wait_time))
-        alldata = qtt.measurements.scans.scan1D(sd.station, scanjob=scanjob1)
+        if sd.verbose:
+            print('sensingdot_t: scan1D: gate %s, wait_time %.3f' % (sd.gg[1], wait_time))
+        alldata = qtt.measurements.scans.scan1D(sd.station, scanjob=scanjob1, verbose=sd.verbose)
         return alldata
 
     def detuning_scan(sd, stepsize=2, nsteps=5, verbose=1, fig=None):
@@ -353,8 +356,7 @@ class sensingdot_t:
             print('autoTune: could not find good peak')
 
         if sd.verbose:
-            print(
-                'sensingdot_t: autotune complete: value %.1f [mV]' % sd.sdval[1])
+            print('sensingdot_t: autotune complete: value %.1f [mV]' % sd.sdval[1])
         return sd.sdval[1], alldata
 
     def _process_scan(self, alldata, useslopes=True, fig=None, invert=False, verbose=0):
@@ -465,8 +467,7 @@ class sensingdot_t:
             raise qtt.exceptions.CalibrationException('fastTune: could not find good peak')
 
         if self.verbose:
-            print(
-                'sensingdot_t: autotune complete: value %.1f [mV]' % self.sdval[1])
+            print('sensingdot_t: autotune complete: value %.1f [mV]' % self.sdval[1])
 
         return self.sdval[1], alldata
 

--- a/src/tests/unittests/test_data.py
+++ b/src/tests/unittests/test_data.py
@@ -114,13 +114,13 @@ class TestData(unittest.TestCase):
         h = qcodes.data.hdf5_format.HDF5Format()
         g = qcodes.data.gnuplot_format.GNUPlotFormat()
 
-        io = qcodes.data.io.DiskIO(tempfile.mkdtemp())
+        disk_io = qcodes.data.io.DiskIO(tempfile.mkdtemp())
         dd = []
         name = qcodes.DataSet.location_provider.base_record['name']
         for jj, fmt in enumerate([g, h]):
             ds = qcodes.tests.data_mocks.DataSet2D(name='format%d' % jj)
             ds.formatter = fmt
-            ds.io = io
+            ds.io = disk_io
             ds.add_metadata({'1': 1, '2': [2, 'x'], 'np': np.array([1, 2.])})
             ds.write(write_metadata=True)
             dd.append(ds.location)
@@ -130,7 +130,7 @@ class TestData(unittest.TestCase):
         for _, location in enumerate(dd):
             if verbose:
                 print('load %s' % location)
-            r = load_dataset(location, io=io)
+            r = load_dataset(location, io=disk_io)
             if verbose:
                 print(r)
 
@@ -384,7 +384,7 @@ class TestMakeDataSet(unittest.TestCase):
         p = ManualParameter('dummy')
         x = p[0:10:1]
         y = None
-        data_set, tuple_names = qtt.data.makeDataSet1D(x, ['y1', 'y2'], y, return_names=True)
+        data_set = qtt.data.makeDataSet1D(x, ['y1', 'y2'], y, return_names=False)
         self.assertTrue(np.array_equal(data_set.dummy, x))
         self.assertTrue(data_set.y1.shape == (10,))
         self.assertTrue(data_set.y2.shape == (10,))
@@ -473,8 +473,8 @@ class TestMakeDataSet(unittest.TestCase):
             stream_handler = logging.StreamHandler(sys.stdout)
             logging.getLogger().addHandler(stream_handler)
 
-            data_set = qtt.data.makeDataSet2Dplain('horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], 'z',
-                                                   np.arange(3 * 5).reshape((3, 5)), xunit='mV', yunit='Hz', zunit='A')
+            _ = qtt.data.makeDataSet2Dplain('horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], 'z',
+                                            np.arange(3 * 5).reshape((3, 5)), xunit='mV', yunit='Hz', zunit='A')
 
             # Verify warning
             print_string = mock_stdout.getvalue()
@@ -486,9 +486,9 @@ class TestMakeDataSet(unittest.TestCase):
             stream_handler = logging.StreamHandler(sys.stdout)
             logging.getLogger().addHandler(stream_handler)
 
-            data_set = qtt.data.makeDataSet2Dplain('horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], ['z1', 'z2'],
-                                                   [np.arange(3 * 4).reshape((3, 4)), np.arange(3 * 5).reshape((3, 5))],
-                                                   xunit='mV', yunit='Hz', zunit='A')
+            _ = qtt.data.makeDataSet2Dplain('horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], ['z1', 'z2'],
+                                            [np.arange(3 * 4).reshape((3, 4)), np.arange(3 * 5).reshape((3, 5))],
+                                            xunit='mV', yunit='Hz', zunit='A')
 
             # Verify warning
             print_string = mock_stdout.getvalue()
@@ -634,7 +634,7 @@ class TestMakeDataSet(unittest.TestCase):
             stream_handler = logging.StreamHandler(sys.stdout)
             logging.getLogger().addHandler(stream_handler)
 
-            data_set = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
+            _ = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
 
             # Verify warning
             print_string = mock_stdout.getvalue()
@@ -652,7 +652,7 @@ class TestMakeDataSet(unittest.TestCase):
             stream_handler = logging.StreamHandler(sys.stdout)
             logging.getLogger().addHandler(stream_handler)
 
-            data_set = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
+            _ = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
 
             # Verify warning
             print_string = mock_stdout.getvalue()

--- a/src/tests/unittests/test_data.py
+++ b/src/tests/unittests/test_data.py
@@ -1,4 +1,8 @@
+import io
+import sys
 import unittest
+from unittest.mock import patch
+import logging
 import time
 import numpy as np
 import matplotlib.pyplot as plt
@@ -184,8 +188,18 @@ class TestMakeDataSet(unittest.TestCase):
     def test_makedataset1dplain_shape_measuredata_list_nok2(self):
         x = np.arange(0, 10)
         y = np.arange(1, 11)
-        self.assertRaisesRegex(ValueError, 'The number of measurement names does not match the number of measurements',
-                               qtt.data.makeDataSet1Dplain, 'x', x, 'y1', [y, y])
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet1Dplain('x', x, 'y1', [y, y])
+            self.assertTrue(np.array_equal(data_set.x, x))
+            self.assertTrue(np.array_equal(data_set.y1, [y, y]))
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
 
     def test_makedataset1dplain_type_yname_parameter(self):
         x = np.arange(0, 10)
@@ -207,15 +221,74 @@ class TestMakeDataSet(unittest.TestCase):
     def test_dataset1dplain_shape_measuredata_nok(self):
         x = np.arange(0, 8)
         y = np.arange(1, 11)
-        self.assertRaisesRegex(ValueError, 'Measured data must be a sequence with shape matching the setpoint arrays',
-                               qtt.data.makeDataSet1Dplain, 'x', x, ['y1', 'y2'], [y, y])
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet1Dplain('x', x, ['y1', 'y2'], [y, y])
+            self.assertTrue(np.array_equal(data_set.x, x))
+            self.assertTrue(np.array_equal(data_set.y1, y))
+            self.assertTrue(np.array_equal(data_set.y2, y))
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
 
     def test_dataset1dplain_shape_measuredata_second_nok(self):
         x = np.arange(0, 8)
         y1 = np.arange(1, 9)
         y2 = np.arange(1, 10)
-        self.assertRaisesRegex(ValueError, 'Measured data must be a sequence with shape matching the setpoint arrays',
-                               qtt.data.makeDataSet1Dplain, 'x', x, ['y1', 'y2'], [y1, y2])
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet1Dplain('x', x, ['y1', 'y2'], [y1, y2])
+            self.assertTrue(np.array_equal(data_set.x, x))
+            self.assertTrue(np.array_equal(data_set.y1, y1))
+            self.assertTrue(np.array_equal(data_set.y2, y2))
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
+
+    def test_dataset1dplain_right_shape(self):
+        x = [1, 2, 3]
+        y = np.array([1, 2, 3]).reshape((3,))
+        data_set = qtt.data.makeDataSet1Dplain('x', x, 'y', y)
+        self.assertTrue(np.array_equal(data_set.x, x))
+        self.assertTrue(np.array_equal(data_set.y, y))
+
+    def test_dataset1dplain_other_shape(self):
+        x = [1, 2, 3]
+        y = np.array([1, 2, 3]).reshape((3, 1))
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet1Dplain('x', x, 'y', y)
+            self.assertTrue(np.array_equal(data_set.x, x))
+            self.assertTrue(np.array_equal(data_set.y, y))
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
+
+    def test_dataset1dplain_no_data(self):
+        x = [1, 2, 3]
+        y = None
+        data_set = qtt.data.makeDataSet1Dplain('x', x, 'y', y)
+        self.assertTrue(np.array_equal(data_set.x, x))
+
+    def test_dataset1dplain_split_2D_input(self):
+        x = [1, 2, 3]
+        y = np.random.rand(2, 3)
+        data_set = qtt.data.makeDataSet1Dplain('x', x, ['y1', 'y2'], y)
+        self.assertTrue(np.array_equal(data_set.y1, y[0]))
+        self.assertTrue(np.array_equal(data_set.y2, y[1]))
+        self.assertTrue(np.array_equal(data_set.x, x))
 
     def test_makedataset1d_not_return_names(self):
         p = ManualParameter('dummy')
@@ -259,27 +332,73 @@ class TestMakeDataSet(unittest.TestCase):
         x = p[0:10:1]
         yname = 'measured'
         y = [np.arange(len(x)).reshape((len(x))), np.arange(len(x)).reshape((len(x)))]
-        self.assertRaisesRegex(ValueError, 'The number of measurement names does not match the number of measurements',
-                               qtt.data.makeDataSet1D, x, yname, y, return_names=False)
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet1D(x, yname, y, return_names=False)
+            self.assertTrue(np.array_equal(data_set.dummy, x))
+            self.assertTrue(np.array_equal(data_set.measured, y))
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
 
     def test_makedataset1d_shape_measuredata_nok(self):
         p = ManualParameter('dummy')
         x = p[0:10:1]
         y = [np.arange(len(x)+1)]
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
 
-        self.assertRaisesRegex(ValueError,
-                               'Measured data must be a sequence with shape matching the setpoint arrays shape',
-                               qtt.data.makeDataSet1D, x, 'y', y, return_names=False)
+            data_set = qtt.data.makeDataSet1D(x, 'y', y, return_names=False)
+            self.assertTrue(np.array_equal(data_set.dummy, x))
+            self.assertTrue(np.array_equal(data_set.y, y))
 
-    def test_makedataset1d_shape_measuredata_second_nok(self):
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
+
+    def test_makedataset1d_shape_second_item_measuredata_nok(self):
         p = ManualParameter('dummy')
         x = p[0:10:1]
         y = [np.arange(len(x)), np.arange(len(x)+1)]
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
 
-        self.assertRaisesRegex(ValueError,
-                               'Measured data must be a sequence with shape matching the setpoint arrays shape',
-                               qtt.data.makeDataSet1D, x,
-                               ['y1', 'y2'], y, return_names=False)
+            data_set = qtt.data.makeDataSet1D(x, ['y1', 'y2'], y, return_names=False)
+            self.assertTrue(np.array_equal(data_set.dummy, x))
+            self.assertTrue(np.array_equal(data_set.y1, y[0]))
+            self.assertTrue(np.array_equal(data_set.y2, y[1]))
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
+
+    def test_makedataset1d_no_data(self):
+        p = ManualParameter('dummy')
+        x = p[0:10:1]
+        y = None
+        data_set, tuple_names = qtt.data.makeDataSet1D(x, ['y1', 'y2'], y, return_names=True)
+        self.assertTrue(np.array_equal(data_set.dummy, x))
+        self.assertTrue(data_set.y1.shape == (10,))
+        self.assertTrue(data_set.y2.shape == (10,))
+
+    def test_makedataset1d_return_names(self):
+        p = ManualParameter('dummy')
+        x = p[0:10:1]
+        y = None
+        data_set, tuple_names = qtt.data.makeDataSet1D(x, ['y1', 'y2'], y, return_names=True)
+        self.assertTrue(np.array_equal(data_set.dummy, x))
+        # check return names
+        self.assertTrue(tuple_names[0] == 'dummy')
+        self.assertTrue(tuple_names[1][0] == 'y1')
+        self.assertTrue(tuple_names[1][1] == 'y2')
 
     def test_dataset_labels_dataset2dplain(self):
         v = [0]
@@ -350,15 +469,31 @@ class TestMakeDataSet(unittest.TestCase):
         self.assertTrue(np.array_equal(data_set.arrays['z'], z))
 
     def test_dataset2dplain_shape_measuredata_nok(self):
-        self.assertRaisesRegex(ValueError, 'Measured data must be a sequence with shape matching the setpoint arrays',
-                               qtt.data.makeDataSet2Dplain, 'horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], 'z',
-                               np.arange(3 * 5).reshape((3, 5)), xunit='mV', yunit='Hz', zunit='A')
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet2Dplain('horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], 'z',
+                                                   np.arange(3 * 5).reshape((3, 5)), xunit='mV', yunit='Hz', zunit='A')
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
 
     def test_dataset2dplain_shape_measuredata_second_nok(self):
-        self.assertRaisesRegex(ValueError, 'Measured data must be a sequence with shape matching the setpoint arrays',
-                               qtt.data.makeDataSet2Dplain, 'horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.],
-                               ['z1', 'z2'], [np.arange(3 * 4).reshape((3, 4)), np.arange(3 * 5).reshape((3, 5))],
-                               xunit='mV', yunit='Hz', zunit='A')
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet2Dplain('horizontal', [0., 1, 2, 3], 'vertical', [0, 1, 2.], ['z1', 'z2'],
+                                                   [np.arange(3 * 4).reshape((3, 4)), np.arange(3 * 5).reshape((3, 5))],
+                                                   xunit='mV', yunit='Hz', zunit='A')
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
 
     def test_dataset2dplain_no_measuredata(self):
         v = [0, 1, 2.]
@@ -411,7 +546,7 @@ class TestMakeDataSet(unittest.TestCase):
         self.assertTrue(tuple_names[0][1] == 'dummy2')
         self.assertTrue(tuple_names[1][0] == 'measured')
 
-    def test_makedataset2d_preset_data_is_arry(self):
+    def test_makedataset2d_preset_data_no_list(self):
         p1 = ManualParameter('dummy1')
         p2 = ManualParameter('dummy2')
         x = p1[0:10:1]
@@ -419,13 +554,8 @@ class TestMakeDataSet(unittest.TestCase):
         m1 = ManualParameter('measurement1')
         measure_names = [m1]
         preset_data = np.ones((len(x), len(y)))
-        data_set = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
-
-        # check attribute
-        self.assertTrue(np.array_equal(data_set.dummy1, x))
-        self.assertTrue(np.array_equal(data_set.measurement1, preset_data))
-        # check array
-        self.assertTrue(np.array_equal(data_set.arrays['measurement1'], preset_data))
+        self.assertRaisesRegex(ValueError, 'The number of measurement names does not match the number of measurements',
+                               qtt.data.makeDataSet2D, x, y, measure_names, preset_data=preset_data, return_names=False)
 
     def test_makedataset2d_shape_measure_names_parameters(self):
         p1 = ManualParameter('dummy1')
@@ -500,9 +630,16 @@ class TestMakeDataSet(unittest.TestCase):
         y = p2[0:4:1]
         measure_names = ['measured1', 'measured2']
         preset_data = [np.ones((len(x) + 1, len(y))), np.ones((len(x), len(y)))]
-        self.assertRaisesRegex(ValueError,
-                               'Measured data must be a sequence with shape matching the setpoint arrays shape',
-                               qtt.data.makeDataSet2D, x, y, measure_names, preset_data=preset_data, return_names=False)
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)
 
     def test_makedataset2d_shape_measuredata_second_nok(self):
         p1 = ManualParameter('dummy1')
@@ -511,6 +648,13 @@ class TestMakeDataSet(unittest.TestCase):
         y = p2[0:4:1]
         measure_names = ['measured1', 'measured2']
         preset_data = [np.ones((len(x), len(y))), np.ones((len(x) + 1, len(y)))]
-        self.assertRaisesRegex(ValueError,
-                               'Measured data must be a sequence with shape matching the setpoint arrays shape',
-                               qtt.data.makeDataSet2D, x, y, measure_names, preset_data=preset_data, return_names=False)
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            logging.getLogger().addHandler(stream_handler)
+
+            data_set = qtt.data.makeDataSet2D(x, y, measure_names, preset_data=preset_data, return_names=False)
+
+            # Verify warning
+            print_string = mock_stdout.getvalue()
+            self.assertIn('Shape of measured data does not match setpoint shape', print_string)
+            logging.getLogger().removeHandler(stream_handler)


### PR DESCRIPTION
* Fixed bug described in OP-57 and checked backwards compatibility.
* Instead of an error a warning is now generated when the shape of the measurement is different than the shape of the preset_data (setpoint).
* Added and changed unit tests for the examples in ticket OP-57 and more