### PR TITLE
add integration tests back to automated testing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 python_files = *.py
 python_classes =
 python_functions = test_*
-addopts = --pyargs src/tests/unittests
+addopts = --pyargs src/tests/unittests src/tests/integration
 
 # exclude some directories from searching to save time
 norecursedirs = .svn _build tmp* .git docs untitled* deprecated* build dist .cache


### PR DESCRIPTION
@CumulonimbusCalvus @QFer The integration tests should also be executed.

In a different PR we could split the execution of the two types of parameters. That takes a little care to make sure the coverage is ok. 