### PR TITLE
[OP-64] Move mock imports to unittest.mock.

### DIFF
--- a/docs/notebooks/run_notebooks.sh
+++ b/docs/notebooks/run_notebooks.sh
@@ -16,8 +16,5 @@ jupyter nbconvert --to notebook --execute docs/notebooks/analysis/example_ohmic.
 jupyter nbconvert --to notebook --execute docs/notebooks/analysis/example_onedot_scan.ipynb
 jupyter nbconvert --to notebook --execute docs/notebooks/analysis/example_PAT_fitting.ipynb
 jupyter nbconvert --to notebook --execute docs/notebooks/analysis/example_polFitting.ipynb
-
 jupyter nbconvert --to notebook --execute docs/notebooks/simulation/example_PAT_simulations.ipynb
-
 jupyter nbconvert --to notebook --execute docs/notebooks/datasets/example_dataset_processing.ipynb
-

--- a/src/tests/unittests/measurements/acquisition/test_uhfli_stimulus.py
+++ b/src/tests/unittests/measurements/acquisition/test_uhfli_stimulus.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 from qilib.utils import PythonJsonStructure
 
 from qtt.measurements.acquisition import UHFLIStimulus

--- a/src/tests/unittests/measurements/processing/test_signal_processor_runner.py
+++ b/src/tests/unittests/measurements/processing/test_signal_processor_runner.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from mock import patch
+from unittest.mock import patch
 from numpy import array_equal
 from numpy.ma import array
 from qilib.data_set import DataSet, DataArray


### PR DESCRIPTION
Currently there are unittests which import mocks like `from mock import ...`. The mocking framework is also available directly via `unittest.mock`.

Changed all mock import to use the `unittest.mock`.
Should solve issue #610.