### PR TITLE
fixing a bug in the function setSingleStep by adding a try statement

### DIFF
--- a/src/qtt/gui/parameterviewer.py
+++ b/src/qtt/gui/parameterviewer.py
@@ -235,10 +235,13 @@ class ParameterViewer(QtWidgets.QTreeWidget):
         for instrument_name in names:
             lst = self._itemsdict[instrument_name]
             for parameter_name in lst:
-                box = lst[parameter_name]['double_box']
-
-                if box is not None:
-                    box.setSingleStep(value)
+                try:
+                    box = lst[parameter_name]['double_box']
+    
+                    if box is not None:
+                        box.setSingleStep(value)
+                except:
+                    continue
 
     def _valueChanged(self, instrument_name: str, parameter_name: str, value: Any, *args, **kwargs):
         """ Callback used to update values in an instrument """


### PR DESCRIPTION
The for-loop cycles through all objects in the parameter viewer dict. The first one of each instrument is the QTreeWidget, where it expects a dict. Adding the try-except solves the issue.

@peendebak 