### PR TITLE
Fix travis builds for VideoMode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 python_files = *.py
 python_classes =
 python_functions = test_*
-addopts = -s -v --pyargs src/tests/unittests src/tests/integration
+addopts = --pyargs src/tests/unittests src/tests/integration
 
 # exclude some directories from searching to save time
 norecursedirs = .svn _build tmp* .git docs untitled* deprecated* build dist .cache

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@
 python_files = *.py
 python_classes =
 python_functions = test_*
-addopts = --pyargs src/tests/unittests src/tests/integration
+addopts = -s -v --pyargs src/tests/unittests src/tests/integration
 
 # exclude some directories from searching to save time
 norecursedirs = .svn _build tmp* .git docs untitled* deprecated* build dist .cache

--- a/src/qtt/gui/live_plotting.py
+++ b/src/qtt/gui/live_plotting.py
@@ -518,6 +518,16 @@ class livePlot(QtCore.QObject):
 
         self.plotwin.scene().sigMouseClicked.connect(self._onClick)
 
+    def __del__(self):
+        print(f'## {self.__class__} destructor')
+        self.stopreadout()
+        pyqtgraph.mkQApp().processEvents()
+        self.close()
+        parent = super()
+        if hasattr(parent, '__del__'):
+            parent.__del__() 
+        print(f'{self.__class__} destructor done')
+        
     def _onClick(self, event):
         image_pt = self.plot.mapFromScene(event.scenePos())
 

--- a/src/qtt/gui/live_plotting.py
+++ b/src/qtt/gui/live_plotting.py
@@ -5,6 +5,7 @@ import numpy as np
 from functools import partial
 import qtpy.QtWidgets as QtWidgets
 import qtpy.QtCore as QtCore
+from qtpy.QtCore import Signal
 import pyqtgraph as pg
 import pyqtgraph
 import pyqtgraph.multiprocess as mp
@@ -374,7 +375,6 @@ class livePlot(QtCore.QObject):
                         measurement result (alpha) and the previous measurement result (1-alpha), default value 0.3
     """
 
-    from qtpy.QtCore import Signal
     sigMouseClicked = Signal(object)
 
     def __init__(

--- a/src/qtt/gui/live_plotting.py
+++ b/src/qtt/gui/live_plotting.py
@@ -531,6 +531,7 @@ class livePlot(QtCore.QObject):
         if self.verbose:
             print('LivePlot.close()')
         self.stopreadout()
+        pyqtgraph.mkQApp().processEvents()
         self.win.close()
 
     def resetdata(self):

--- a/src/qtt/gui/live_plotting.py
+++ b/src/qtt/gui/live_plotting.py
@@ -520,7 +520,7 @@ class livePlot(QtCore.QObject):
         self.close()
         parent = super()
         if hasattr(parent, '__del__'):
-            parent.__del__() 
+            parent.__del__()
 
     def _onClick(self, event):
         image_pt = self.plot.mapFromScene(event.scenePos())
@@ -538,6 +538,7 @@ class livePlot(QtCore.QObject):
         pyqtgraph.mkQApp().processEvents()
         self.win.close()
 
+    @qtt.utilities.tools.rdeprecated(txt='method not used any more', expire='1 Dec 2019')
     def resetdata(self):
         self.idx = 0
         self.data = None
@@ -665,6 +666,7 @@ class livePlot(QtCore.QObject):
         time.sleep(0.00001)
 
     def enable_averaging(self, value):
+        """ Enabling rolling average """
         self._averaging_enabled = value
         if self.verbose >= 1:
             if self._averaging_enabled == 2:
@@ -685,8 +687,9 @@ class livePlot(QtCore.QObject):
     def startreadout(self, callback=None, rate=30, maxidx=None):
         """
         Args:
+            callback (None or method): Method to call on update
             rate (float): sample rate in ms
-
+            maxidx (None or int): Stop reading if the index is larger than the maxidx
         """
         if maxidx is not None:
             self.maxidx = maxidx
@@ -697,6 +700,7 @@ class livePlot(QtCore.QObject):
             print('live_plotting: start readout: rate %.1f Hz' % rate)
 
     def stopreadout(self):
+        """ Stop the readout loop """
         if self.verbose:
             print('live_plotting: stop readout')
         self.timer.stop()

--- a/src/qtt/gui/live_plotting.py
+++ b/src/qtt/gui/live_plotting.py
@@ -352,8 +352,6 @@ class RdaControl(QtWidgets.QMainWindow):
         if self.verbose:
             print('valueChanged: %s %s' % (name, value))
         self.rda.set(name, value)
-        # self.label.setStyleSheet("QLabel { background-color : #baccba;
-        # margin: 2px; padding: 2px; }");
 
 
 # legacy name
@@ -502,9 +500,7 @@ class livePlot(QtCore.QObject):
 
         def connect_slot(target):
             """ Create a slot by dropping signal arguments """
-            # @Slot()
             def signal_drop_arguments(*args, **kwargs):
-                # print('call %s' % target)
                 target()
             return signal_drop_arguments
 
@@ -519,15 +515,13 @@ class livePlot(QtCore.QObject):
         self.plotwin.scene().sigMouseClicked.connect(self._onClick)
 
     def __del__(self):
-        print(f'## {self.__class__} destructor')
         self.stopreadout()
         pyqtgraph.mkQApp().processEvents()
         self.close()
         parent = super()
         if hasattr(parent, '__del__'):
             parent.__del__() 
-        print(f'{self.__class__} destructor done')
-        
+
     def _onClick(self, event):
         image_pt = self.plot.mapFromScene(event.scenePos())
 

--- a/src/qtt/measurements/videomode.py
+++ b/src/qtt/measurements/videomode.py
@@ -338,7 +338,7 @@ class VideoMode:
             liveplot.deleteLater()
         if self.verbose>=2:
             print(f'{self.__class__}: call mainwin.close')
-            
+
         self.mainwin.close()
 
     def get_dataset(self):

--- a/src/qtt/measurements/videomode.py
+++ b/src/qtt/measurements/videomode.py
@@ -330,6 +330,15 @@ class VideoMode:
     def close(self):
         """ Stop the videomode and close the GUI"""
         self.stop()
+        
+        if self.verbose>=2:
+            print(f'{self.__class__}: close')
+        for liveplot in self.lp:
+            liveplot.stopreadout()
+            liveplot.deleteLater()
+        if self.verbose>=2:
+            print(f'{self.__class__}: call mainwin.close')
+            
         self.mainwin.close()
 
     def get_dataset(self):

--- a/src/qtt/measurements/videomode.py
+++ b/src/qtt/measurements/videomode.py
@@ -330,7 +330,7 @@ class VideoMode:
     def close(self):
         """ Stop the videomode and close the GUI"""
         self.stop()
-        
+
         if self.verbose>=2:
             print(f'{self.__class__}: close')
         for liveplot in self.lp:

--- a/src/tests/integration/measurements/test_videomode_processor.py
+++ b/src/tests/integration/measurements/test_videomode_processor.py
@@ -1,4 +1,6 @@
 import unittest
+import pyqtgraph
+import time
 
 import qcodes
 import qtt.data
@@ -12,6 +14,8 @@ class TestVideoModeProcessor(unittest.TestCase):
 
 
     def test_DummyVideoModeProcessor(self):
+        qtapp = pyqtgraph.mkQApp()
+
         station = qtt.simulation.virtual_dot_array.initialize()
         dummy_processor = DummyVideoModeProcessor(station)
         vm = VideoMode(station, Naverage=25, diff_dir=None, verbose=1,
@@ -24,3 +28,5 @@ class TestVideoModeProcessor(unittest.TestCase):
         qtt.simulation.virtual_dot_array.close()
         self.assertIsInstance(datasets[0], qcodes.DataSet)
 
+        pyqtgraph.processEvents()
+        time.sleep(.1)

--- a/src/tests/integration/measurements/test_videomode_processor.py
+++ b/src/tests/integration/measurements/test_videomode_processor.py
@@ -28,5 +28,5 @@ class TestVideoModeProcessor(unittest.TestCase):
         qtt.simulation.virtual_dot_array.close()
         self.assertIsInstance(datasets[0], qcodes.DataSet)
 
-        pyqtgraph.processEvents()
+        qtapp.processEvents()
         time.sleep(.1)


### PR DESCRIPTION
This PR fixes semi-random crashes on travis by making sure all events in the event loop have been processed before destroying Qt objects.