### PR TITLE
use M4i driver from qcodes_contrib_drivers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(name='qtt',
       packages=find_packages(where='./src'),
       install_requires=[
           'matplotlib>=3.0', 'pandas', 'attrs', 'dulwich', 'qtpy', 'nose', 'hickle', 'pyzmqrpc',
-          'numpy>=1.15', 'scikit-image', 'IPython>=0.1', 'qcodes>=0.5.0', 'Polygon3',
+          'numpy>=1.15', 'scikit-image', 'IPython>=0.1', 'qcodes>=0.5.0', 'qcodes-contrib-drivers', 'Polygon3',
           'scipy', 'pyqtgraph', 'qupulse', 'PyQt5','apscheduler', 'qilib', 'dataclasses', 'lmfit'
       ],
       tests_require=['pytest'],

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -1264,8 +1264,12 @@ def get_sampling_frequency(instrument_handle):
     if isinstance(instrument_handle, AcquisitionScopeInterface):
         return instrument_handle.sample_rate
     try:
+        import qcodes_contrib_drivers.drivers.Spectrum.M4i
+        if isinstance(qcodes_contrib_drivers.drivers.Spectrum.M4i):
+            return instrument_handle.sample_rate()
         import qcodes.instrument_drivers.Spectrum.M4i
         if isinstance(instrument_handle, qcodes.instrument_drivers.Spectrum.M4i.M4i):
+            warnings.warn('please use the M4i driver from qcodes_contrib_drivers')
             return instrument_handle.sample_rate()
     except ImportError:
         pass

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -1267,6 +1267,9 @@ def get_sampling_frequency(instrument_handle):
         import qcodes_contrib_drivers.drivers.Spectrum.M4i
         if isinstance(qcodes_contrib_drivers.drivers.Spectrum.M4i):
             return instrument_handle.sample_rate()
+    except ImportError:
+        pass
+    try:
         import qcodes.instrument_drivers.Spectrum.M4i
         if isinstance(instrument_handle, qcodes.instrument_drivers.Spectrum.M4i.M4i):
             warnings.warn('please use the M4i driver from qcodes_contrib_drivers')


### PR DESCRIPTION
The QCoDeS project will move all non-MS supported drivers to a separate repository. This PR:

* Adds `qcodes_contrib_drivers` as an install requirement (repo is https://github.com/QCoDeS/Qcodes_contrib_drivers)
* Uses the M4i driver from `qcodes_contrib_drivers` (there aready is a PR merged in `qcodes_contrib_drivers` that will not be merged in `QCoDeS`)