### PR TITLE
Instruments should get the correct name

### DIFF
--- a/src/qtt/instrument_drivers/adapters/time_stamp_instrument_adapter.py
+++ b/src/qtt/instrument_drivers/adapters/time_stamp_instrument_adapter.py
@@ -8,7 +8,7 @@ from qtt.instrument_drivers.TimeStamp import TimeStampInstrument
 class TimeStampInstrumentAdapter(CommonInstrumentAdapter):
     def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument = TimeStampInstrument(name=self._name)
+        self._instrument = TimeStampInstrument(name=self._instrument_name)
 
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:
         return parameters

--- a/src/qtt/instrument_drivers/adapters/virtual_awg_instrument_adapter.py
+++ b/src/qtt/instrument_drivers/adapters/virtual_awg_instrument_adapter.py
@@ -13,8 +13,8 @@ class VirtualAwgInstrumentAdapter(InstrumentAdapter):
     def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
         super().__init__(address, instrument_name)
 
-        settings_instrument = SettingsInstrument(f'settings_{instrument_name}')
-        self._instrument: VirtualAwg = VirtualAwg(name=instrument_name, settings=settings_instrument)
+        settings_instrument = SettingsInstrument(f'settings_{self._instrument_name}')
+        self._instrument: VirtualAwg = VirtualAwg(name=self._instrument_name, settings=settings_instrument)
         self._adapters: Dict[str, InstrumentAdapter] = {}
 
     def apply(self, config: PythonJsonStructure) -> None:

--- a/src/qtt/instrument_drivers/adapters/virtual_dac_instrument_adapter.py
+++ b/src/qtt/instrument_drivers/adapters/virtual_dac_instrument_adapter.py
@@ -12,7 +12,7 @@ class VirtualDACInstrumentAdapter(InstrumentAdapter):
 
     def __init__(self, address: str, instrument_name: Optional[str] = None) -> None:
         super().__init__(address, instrument_name)
-        self._instrument = VirtualDAC(self._name, instruments=[], gate_map={})
+        self._instrument = VirtualDAC(self._instrument_name, instruments=[], gate_map={})
         self._dac_adapters: Dict[str, VirtualDAC] = {}
 
     def _filter_parameters(self, parameters: PythonJsonStructure) -> PythonJsonStructure:


### PR DESCRIPTION
Instruments, instantiated in an adapter got the name of the adapter but not the name from the optional field `instrument_name`