### PR TITLE
derive calibration exception from normal exception

### DIFF
--- a/src/qtt/exceptions.py
+++ b/src/qtt/exceptions.py
@@ -2,6 +2,7 @@ class MissingOptionalPackageWarning(UserWarning, ValueError):
     """ An optional package is missing """
     pass
 
+
 class PackageVersionWarning(UserWarning):
     """ A package has the incorrect version """
     pass

--- a/src/qtt/exceptions.py
+++ b/src/qtt/exceptions.py
@@ -3,10 +3,10 @@ class MissingOptionalPackageWarning(UserWarning, ValueError):
     pass
 
 class PackageVersionWarning(UserWarning):
-    """ An package has the incorrect version """
+    """ A package has the incorrect version """
     pass
 
 
-class CalibrationException(BaseException):
+class CalibrationException(Exception):
     """ Exception thrown for a bad calibration """
     pass

--- a/src/tests/unittests/test_exceptions.py
+++ b/src/tests/unittests/test_exceptions.py
@@ -5,7 +5,7 @@ import qtt.exceptions
 class TestExceptions(unittest.TestCase):
 
     def test_calibration_exception(self):
-        self.assertTrue(issubclass(qtt.exceptions.CalibrationException, BaseException))
+        self.assertTrue(issubclass(qtt.exceptions.CalibrationException, Exception))
 
     def test_PackageVersionWarning(self):
         self.assertTrue(issubclass(qtt.exceptions.PackageVersionWarning, UserWarning))


### PR DESCRIPTION
According to the docs https://docs.python.org/3/library/exceptions.html any user defined exception should be based on the normal `Exception`