### PR TITLE
Fix inverse argument of VirtualGates.print_matrix

### DIFF
--- a/src/qtt/instrument_drivers/virtual_gates.py
+++ b/src/qtt/instrument_drivers/virtual_gates.py
@@ -413,10 +413,16 @@ class VirtualGates(Instrument):
 
         Args:
             fig (int): number of figure window
+            inverse (bool): If True then plot the inverse matrix
         """
-        xlabels = self.pgates()
-        ylabels = self.vgates()
-        m = self.get_crosscap_matrix()
+        if inverse:
+            m = self.get_crosscap_matrix_inv()
+            xlabels = self.vgates()
+            ylabels = self.pgates()
+        else:
+            m = self.get_crosscap_matrix()
+            xlabels = self.pgates()
+            ylabels = self.vgates()
         x = range(0, len(xlabels))
         y = range(0, len(ylabels))
 


### PR DESCRIPTION
The `inverse` argument of `VirtualGates` was not implemented. 