### PR TITLE
Fix/sweep values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix bug in HDAWG8 driver where the gain was set to the range, whereas it should be gain = range/2 (#720)
-- Fix bug in generation of stepvalues for vector scans
-- Packages 'tests' are not installed anymore. These packages gave problems with loading similar named modules in other packages.
+- Fix bug in generation of step values for vector scans (#723)
+- Packages 'tests' are not installed anymore. These packages gave problems with loading similar named modules in other packages (#724)
 - Fix for deprecated old style qupulse Sequencer test (#733)
 
 ### Security

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -895,7 +895,7 @@ class scanjob_t(dict):
                 diff = abs(sweep_data['end'] - sweep_data['start'])
                 tolerance = 1e-10
                 if int(np.ceil(diff - tolerance)) == 0:
-                    raise ValueError('start and end values must differ at least 1 step value')
+                    raise ValueError('start and end values may not be the same')
 
                 sweep_values = param[sweep_data['start']:sweep_data['end']:sweep_data['step']]
 

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -901,7 +901,7 @@ class scanjob_t(dict):
                                                 stop=sweep_data['end'],
                                                 step=sweep_data['step'])
             else:
-                if steps_lo == 0:
+                if steps_hi == 0:
                     raise ValueError('start and end values may not be the same')
                 sweep_values = param[sweep_data['start']:sweep_data['end']:sweep_data['step']]
 

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -887,22 +887,16 @@ class scanjob_t(dict):
             """ From parameter and sweep data create a SweepFixedValues object. """
             if sweep_data['step'] == 0.:
                 raise ValueError('step value may not be 0')
-            steps = abs((sweep_data['end'] - sweep_data['start']) / sweep_data['step'])
-            tolerance = 1e-10
-            steps_lo = int(np.floor(steps + tolerance))
-            steps_hi = int(np.ceil(steps - tolerance))
 
             if inclusive_end:
-                if steps_lo != steps_hi:
-                    sweep_data['end'] = sweep_data['start'] + steps_lo * sweep_data['step']
-
-                sweep_values = SweepFixedValues(param,
-                                                start=sweep_data['start'],
-                                                stop=sweep_data['end'],
-                                                step=sweep_data['step'])
+                epsilon = 1e-8
+                sweep_values = param[sweep_data['start']:(sweep_data['end'] + epsilon):sweep_data['step']]
             else:
-                if steps_hi == 0:
-                    raise ValueError('start and end values may not be the same')
+                diff = abs(sweep_data['end'] - sweep_data['start'])
+                tolerance = 1e-10
+                if int(np.ceil(diff - tolerance)) == 0:
+                    raise ValueError('start and end values must differ at least 1 step value')
+
                 sweep_values = param[sweep_data['start']:sweep_data['end']:sweep_data['step']]
 
             return sweep_values

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -881,7 +881,18 @@ class scanjob_t(dict):
                         data['step'] = (data['end'] - data['start']) / (length-1)
 
         def _calculate_sweepvalues(param, sweep_data) -> SweepFixedValues:
-            """ From parameter and sweep data create a SweepFixedValues object """
+            """ From parameter and sweep data create a SweepFixedValues object. When (end - start) / step is not an
+            integer value, the end-value will be adjusted (lowered) until it is.
+             """
+            if sweep_data['step'] is not None:
+                steps = abs((sweep_data['end'] - sweep_data['start']) / sweep_data['step'])
+                tolerance = 1e-10
+                steps_lo = int(np.floor(steps + tolerance))
+                steps_hi = int(np.ceil(steps - tolerance))
+
+                if steps_lo != steps_hi:
+                    sweep_data['end'] = sweep_data['start'] + steps_lo * sweep_data['step']
+
             sweep_values = SweepFixedValues(param,
                                             start=sweep_data['start'],
                                             stop=sweep_data['end'],

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -465,7 +465,7 @@ class TestScans(TestCase):
                         # exclusive end-value
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
                                              'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-                        _, sweepvalues = scanjob._convert_scanjob_vec(station)
+                        _ = scanjob._convert_scanjob_vec(station)
 
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
                                              'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
@@ -474,7 +474,7 @@ class TestScans(TestCase):
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
                                              'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
                         # generate a sweeplength so that the step-value doesn't change
-                        _, sweepvalues = scanjob._convert_scanjob_vec(station, sweeplength=((end-start)/step) + 1)
+                        _ = scanjob._convert_scanjob_vec(station, sweeplength=((end-start)/step) + 1)
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
                                              'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
 

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -330,6 +330,16 @@ class TestScans(TestCase):
             self.assertAlmostEqual(actual_val, expected_val, 12)
         self.assertEqual(len(actual_values), 10)
 
+        # exclusive: end - start < step
+        scanjob = scanjob_t({'scantype': 'scan1Dfast',
+                             'sweepdata': {'param': p, 'start': 20, 'end': 20.0050, 'step': .0075}})
+        _, sweepvalues = scanjob._convert_scanjob_vec(station)
+        actual_values = list(sweepvalues)
+        expected_values = [20.0]
+        for actual_val, expected_val in zip(actual_values, expected_values):
+            self.assertAlmostEqual(actual_val, expected_val, 12)
+        self.assertEqual(len(actual_values), 1)
+
         # inclusive end-value
         scanjob = scanjob_t({'scantype': 'scan1Dfast', 'sweepdata': {'param': p, 'start': -2., 'end': 2., 'step': .4}})
         _, sweepvalues = scanjob._convert_scanjob_vec(station, sweeplength=11)
@@ -434,7 +444,7 @@ class TestScans(TestCase):
 
         gates.close()
 
-    def test_convert_scanjob_vec_end_equals_start_raises_exception(self):
+    def test_convert_scanjob_vec_values_raises_exception(self):
         p = Parameter('p', set_cmd=None)
         gates = VirtualIVVI(
             name=qtt.measurements.scans.instrumentName('gates'), model=None)

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -7,7 +7,6 @@ This is part of qtt.
 
 import sys
 import warnings
-import random
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 import tempfile
@@ -467,35 +466,36 @@ class TestScans(TestCase):
         station.gates = gates
 
         idx = 1
-        for idx in range(1, 100):
-            start = -random.randint(1, 20)
-            end = random.randint(1, 20)
-            step = random.randint(1, 40) / (idx * 10)
+        for idx in range(1, 5):
+            for start in range(-5, 1):
+                for end in range(1, 5):
+                    for step_in_range in range(1, 5):
+                        step = step_in_range / (idx * 10)
 
-            # exclusive end-value
-            scanjob = scanjob_t({'scantype': 'scan1Dfast',
-                                 'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-            _, sweepvalues = scanjob._convert_scanjob_vec(station)
+                        # exclusive end-value
+                        scanjob = scanjob_t({'scantype': 'scan1Dfast',
+                                             'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
+                        _, sweepvalues = scanjob._convert_scanjob_vec(station)
 
-            scanjob = scanjob_t({'scantype': 'scan1Dfast',
-                                 'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-            sweepvalues_old = self.ref_calculate_sweepvalues(p, scanjob['sweepdata'])
-            for actual_val, expected_val in zip(list(sweepvalues), list(sweepvalues_old)):
-                self.assertAlmostEqual(actual_val, expected_val, 12)
+                        scanjob = scanjob_t({'scantype': 'scan1Dfast',
+                                             'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
+                        sweepvalues_old = self.ref_calculate_sweepvalues(p, scanjob['sweepdata'])
+                        for actual_val, expected_val in zip(list(sweepvalues), list(sweepvalues_old)):
+                            self.assertAlmostEqual(actual_val, expected_val, 12)
 
-            # inclusive end-value
-            scanjob = scanjob_t({'scantype': 'scan1Dfast',
-                                 'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-            # generate a sweeplength so that the step-value doesn't change
-            _, sweepvalues = scanjob._convert_scanjob_vec(station, sweeplength=((end-start)/step) + 1)
-            scanjob = scanjob_t({'scantype': 'scan1Dfast',
-                                 'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-            sweepvalues_old = self.ref_calculate_sweepvalues(p, scanjob['sweepdata'], True)
-            for actual_val, expected_val in zip(list(sweepvalues), list(sweepvalues_old)):
-                self.assertAlmostEqual(actual_val, expected_val, 12)
+                        # inclusive end-value
+                        scanjob = scanjob_t({'scantype': 'scan1Dfast',
+                                             'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
+                        # generate a sweeplength so that the step-value doesn't change
+                        _, sweepvalues = scanjob._convert_scanjob_vec(station, sweeplength=((end-start)/step) + 1)
+                        scanjob = scanjob_t({'scantype': 'scan1Dfast',
+                                             'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
+                        sweepvalues_old = self.ref_calculate_sweepvalues(p, scanjob['sweepdata'], True)
+                        for actual_val, expected_val in zip(list(sweepvalues), list(sweepvalues_old)):
+                            self.assertAlmostEqual(actual_val, expected_val, 12)
 
         # all the conversions were successful
-        self.assertEqual(idx, 99)
+        self.assertEqual(idx, 4)
         gates.close()
 
     def test_convert_scanjob_vec_scan2Dfast(self):

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -388,6 +388,23 @@ class TestScans(TestCase):
 
         gates.close()
 
+    def test_convert_scanjob_vec_end_equals_start(self):
+        p = Parameter('p', set_cmd=None)
+        gates = VirtualIVVI(
+            name=qtt.measurements.scans.instrumentName('gates'), model=None)
+        station = qcodes.Station(gates)
+        station.gates = gates
+
+        scanjob = scanjob_t({'scantype': 'scan1Dfast',
+                             'sweepdata': {'param': p, 'start': 20, 'end': 20, 'step': .0075}})
+        _, sweepvalues = scanjob._convert_scanjob_vec(station)
+        actual_values = sweepvalues._values
+        self.assertEqual(actual_values[0], 20.0)
+        self.assertEqual(scanjob['sweepdata']['end'], 20)
+        self.assertEqual(sweepvalues._value_snapshot[0]['num'], 1)
+
+        gates.close()
+
     def test_convert_scanjob_vec_adjust_values_randomly_will_never_raise_exception(self):
         p = Parameter('p', set_cmd=None)
         gates = VirtualIVVI(

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -314,16 +314,6 @@ class TestScans(TestCase):
 
         m4i_digitizer.close()
 
-    @staticmethod
-    def ref_calculate_sweepvalues(param, sweepdata, inclusive=False):
-        """ From parameter and sweep data create a SweepFixedValues object """
-        if inclusive:
-            epsilon = 1e-8
-            sweepvalues = param[sweepdata['start']:(sweepdata['end']+epsilon):sweepdata['step']]
-        else:
-            sweepvalues = param[sweepdata['start']:sweepdata['end']:sweepdata['step']]
-        return sweepvalues
-
     def test_convert_scanjob_vec_scan1Dfast(self):
         p = Parameter('p', set_cmd=None)
         gates = VirtualIVVI(
@@ -417,7 +407,7 @@ class TestScans(TestCase):
         actual_values = list(sweepvalues)
         self.assertEqual(actual_values[0], -20.0)
         self.assertAlmostEqual(actual_values[-1], 20.0-.0025, 10)
-        self.assertAlmostEqual(scanjob['sweepdata']['end'], actual_values[-1], 10)
+        self.assertAlmostEqual(scanjob['sweepdata']['end'], 20, 10)
         self.assertEqual(len(actual_values), 5334)
 
         # exclusive end-value
@@ -439,7 +429,7 @@ class TestScans(TestCase):
         actual_values = list(sweepvalues)
         self.assertEqual(actual_values[0], -500.0)
         self.assertAlmostEqual(actual_values[-1], 0.8, 10)
-        self.assertAlmostEqual(scanjob['sweepdata']['end'], actual_values[-1], 10)
+        self.assertAlmostEqual(scanjob['sweepdata']['end'], 1, 10)
         self.assertEqual(len(actual_values), 627)
 
         gates.close()
@@ -458,7 +448,7 @@ class TestScans(TestCase):
 
         gates.close()
 
-    def test_convert_scanjob_vec_adjust_values_randomly_will_never_raise_exception(self):
+    def test_convert_scanjob_vec_range_values_will_not_raise_exception(self):
         p = Parameter('p', set_cmd=None)
         gates = VirtualIVVI(
             name=qtt.measurements.scans.instrumentName('gates'), model=None)
@@ -479,9 +469,6 @@ class TestScans(TestCase):
 
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
                                              'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-                        sweepvalues_old = self.ref_calculate_sweepvalues(p, scanjob['sweepdata'])
-                        for actual_val, expected_val in zip(list(sweepvalues), list(sweepvalues_old)):
-                            self.assertAlmostEqual(actual_val, expected_val, 12)
 
                         # inclusive end-value
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
@@ -490,9 +477,6 @@ class TestScans(TestCase):
                         _, sweepvalues = scanjob._convert_scanjob_vec(station, sweeplength=((end-start)/step) + 1)
                         scanjob = scanjob_t({'scantype': 'scan1Dfast',
                                              'sweepdata': {'param': p, 'start': start, 'end': end, 'step': step}})
-                        sweepvalues_old = self.ref_calculate_sweepvalues(p, scanjob['sweepdata'], True)
-                        for actual_val, expected_val in zip(list(sweepvalues), list(sweepvalues_old)):
-                            self.assertAlmostEqual(actual_val, expected_val, 12)
 
         # all the conversions were successful
         self.assertEqual(idx, 4)


### PR DESCRIPTION
* Adjusted _calculate_sweepvalues. It now always returns a valid SweepFixedValues object and doesn't raise an exception when the range is nog divisable by the stepvalue. The fix will adjust the end value do that the number of steps is fitting in the range.
* Added some extra unit test inclusive a test that fits random generated values for start, end and step.