### PR TITLE
add numdifftools to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'apscheduler', 'attrs', 'dulwich', 'h5py', 'hickle', 'IPython>=0.1', 'lmfit', 'matplotlib>=3.0',
     'numpy>=1.15', 'opencv-python', 'PyQt5', 'pyqtgraph', 'pyvisa', 'pyzmqrpc', 'qcodes>=0.8.0',
     'qcodes-contrib-drivers', 'qilib', 'qtpy', 'qupulse', 'redis', 'scipy>=0.18', 'scikit-image', 'jupyter',
-    'coverage', 'sympy'
+    'coverage', 'sympy', 'numdifftools'
 ] + tests_require
 
 if platform.system() == 'Windows':


### PR DESCRIPTION
qtt uses lmfit for fitting. In order to calculate the covarance of the fit a package called numdifftools is required (see docs https://lmfit.github.io/lmfit-py/fitting.html). When this package was not installed, the following line of code generates an error: https://github.com/QuTech-Delft/qtt/blob/dev/src/qtt/algorithms/allxy.py#L81