### PR TITLE
[OP-NN] fix issue with peak_local_max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[1.2.2] - Unreleased
 ### Added
+- Add example notebook for mongodb (#679)
 - Add analysis results to notes (#712)
+- Update docstrings (#718)
+- Add numdifftools to requirements (#726)
+- Add fitting of sine wave (#731)
 
 ### Changed
 - Prevent tests from writing data to the user directory (#710)
 - Implement functionality for print_matrix argument (#714)
 - Bump bleach from 3.1.0 to 3.1.1 (#717)
 - scanjob_t uses SweepFixedValues (including 'end') instead of slices (excluding 'end') (#722)
+- Bump bleach from 3.1.1 to 3.1.2 (#727)
+- Allow plotting arguments to be passed in drawCrosshair (#728)
 - Use lmfit in fit_gauss_ramsey. The first point of the data is now also used for fitting (#729)
+- Bump bleach from 3.1.2 to 3.1.4 (#730)
+- Update to sine fitting (#734)
 - Replaced chi_squared with reduced chi_squared in allxy fit (#736)
 
 ### Removed
@@ -23,11 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved the deprecated loadOneDotPinchvalues to legacy.py (#722)
 
 ### Fixed
+- Prevent tests from writing data to the user directory (#710)
+- Disable all output channels when restarting the videomode (#711)
 - Fix bug in HDAWG8 driver where the gain was set to the range, whereas it should be gain = range/2 (#720)
 - Fix bug in generation of step values for vector scans (#723)
 - Packages 'tests' are not installed anymore. These packages gave problems with loading similar named modules in other packages (#724)
 - Fix for deprecated old style qupulse Sequencer test (#733)
+- Update qtt to qcodes 0.13.0 (#735)
 - Improved calculation of covariances (#736)
+- Fixed failing unit test depending on order of peak_local_max (#741)
 
 ### Security
 

--- a/src/tests/integration/algorithms/test_generic.py
+++ b/src/tests/integration/algorithms/test_generic.py
@@ -8,13 +8,15 @@ import matplotlib.pyplot as plt
 
 class TestGeneric(unittest.TestCase):
 
-    @staticmethod
-    def test_subpixel(fig=100):
+    def test_subpixel(self, fig=100):
         np.random.seed(2019)
         ims = np.random.rand(40,)**2 + 1e1
         smooth_ims = smoothImage(ims)
 
         mpos = peak_local_max(smooth_ims, min_distance=3).flatten()
+        # make sure the local max are always ordered the same way (descending)
+        mpos[::-1].sort()
+        self.assertListEqual(list(mpos), [34, 20, 14, 7])
         subpos, subval = subpixelmax(smooth_ims, mpos)
 
         np.testing.assert_array_almost_equal(subpos, np.array([34.48945739, 19.7971219, 14.04429215, 7.17665281]),
@@ -50,7 +52,7 @@ class TestBoxcarFilter(unittest.TestCase):
 
     _signal_1D = [1.25, 4.52, 46.36]
     _signal_2D = [[1.25, 4.52, 46.36],
-                 [3.45, 25.66, 6234.6]]
+                  [3.45, 25.66, 6234.6]]
 
     _known_inputs_outputs_1D = [
         ([],
@@ -78,7 +80,7 @@ class TestBoxcarFilter(unittest.TestCase):
          np.array([-1., -1.,  1, -1.,  1., 1.]) / 3.),
 
         (np.array([-0.5, 1.5, 2.5, 3.5, -2.5]),
-         np.array([ 0.5, 3.5, 7.5, 3.5, -1.5]) / 3.),
+         np.array([0.5, 3.5, 7.5, 3.5, -1.5]) / 3.),
     ]
 
     _known_inputs_outputs_2D = [
@@ -122,10 +124,9 @@ class TestBoxcarFilter(unittest.TestCase):
 
         (np.array([[-0.5, 1.5, 2.5, 3.5, -2.5],
                    [-0.5, 1.5, 2.5, 3.5, -2.5]]),
-         np.array([[ 0.5, 3.5, 7.5, 3.5, -1.5],
-                   [ 0.5, 3.5, 7.5, 3.5, -1.5]]) / 3.),
+         np.array([[0.5, 3.5, 7.5, 3.5, -1.5],
+                   [0.5, 3.5, 7.5, 3.5, -1.5]]) / 3.),
     ]
-
 
     def assertFilterOutput(self, signal, kernel, out_exp):
         """Assert that signal generates output close to expectation"""
@@ -140,7 +141,6 @@ class TestBoxcarFilter(unittest.TestCase):
 
             if msg:
                 self.fail(msg)
-
 
     def test_float_inputs(self):
         kernel_1D = TestBoxcarFilter._kernel_size_1D
@@ -164,7 +164,6 @@ class TestBoxcarFilter(unittest.TestCase):
             if np.allclose(int_signal, signal):
                 self.assertFilterOutput(int_signal, kernel_2D, out_exp)
 
-
     def test_wrong_kernel_dimensions(self):
         """
         If the number of dimensions in the kernel is not equal to the number of dimensions
@@ -183,7 +182,6 @@ class TestBoxcarFilter(unittest.TestCase):
         self.assertRaises(RuntimeError, boxcar_filter, signal_2D, kernel_1D)
         self.assertRaises(RuntimeError, boxcar_filter, signal_2D, kernel_3D)
 
-
     def test_invalid_kernel_size(self):
         """
         If any of the dimensions of the kernel has non-positive size, an exception should be raised
@@ -194,6 +192,3 @@ class TestBoxcarFilter(unittest.TestCase):
         self.assertRaises(RuntimeError, boxcar_filter, signal_1D, (-1,))
         self.assertRaises(RuntimeError, boxcar_filter, signal_2D, (3, 0))
         self.assertRaises(RuntimeError, boxcar_filter, signal_2D, (5, -1))
-
-
-

--- a/src/tests/unittests/algorithms/test_generic.py
+++ b/src/tests/unittests/algorithms/test_generic.py
@@ -8,13 +8,15 @@ import matplotlib.pyplot as plt
 
 class TestGeneric(unittest.TestCase):
 
-    @staticmethod
-    def test_subpixel(fig=None):
+    def test_subpixel(self, fig=None):
         np.random.seed(2019)
         ims = np.random.rand(40,)**2 + 1e1
         smooth_ims = smoothImage(ims)
 
         mpos = peak_local_max(smooth_ims, min_distance=3).flatten()
+        # make sure the local max are always ordered the same way (descending)
+        mpos[::-1].sort()
+        self.assertListEqual(list(mpos), [34, 20, 14, 7])
         subpos, subval = subpixelmax(smooth_ims, mpos)
 
         np.testing.assert_array_almost_equal(subpos, np.array([34.48945739, 19.7971219, 14.04429215, 7.17665281]),
@@ -39,5 +41,3 @@ class TestGeneric(unittest.TestCase):
         self.assertTrue(rescaled.size, 45000)
         self.assertSequenceEqual(s, (4, 1.0, 0.25, 1.0))
         plt.close('all')
-
-


### PR DESCRIPTION
* The unit tests that used peak_local_max result didn't take into account that the order of peak local max is not defined. The order was different in the new version.