### PR TITLE
[OP-56] Replace polyintersect inplementation of Polygon3 with shapely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Quantum Technology Toolbox will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Dev
+
+### Changed
+- Replaced implementation of polyintersection from Polygon3 to shapely (#744)
+
 ## \[1.2.2] - 14-5-2020
 ### Added
 - Add example notebook for mongodb (#679)

--- a/setup.py
+++ b/setup.py
@@ -30,25 +30,11 @@ install_requires = [
     'apscheduler', 'attrs', 'dulwich', 'h5py', 'hickle', 'IPython>=0.1', 'lmfit', 'matplotlib>=3.0',
     'numpy>=1.15', 'opencv-python', 'PyQt5', 'pyqtgraph', 'pyvisa', 'pyzmqrpc', 'qcodes>=0.8.0',
     'qcodes-contrib-drivers', 'qilib', 'qtpy', 'qupulse', 'redis', 'scipy>=0.18', 'scikit-image', 'jupyter',
-    'coverage', 'sympy', 'numdifftools'
+    'coverage', 'sympy', 'numdifftools', 'shapely'
 ] + tests_require
 
 if platform.system() == 'Windows':
     install_requires.append('pywin32')
-
-if platform.python_version() < "3.7.0":
-    install_requires.append('Polygon3')
-else:
-    if platform.system() == 'Windows':
-        # When Polygon3 not yet in git-repository get it locally
-        file_path = abspath(getsourcefile(lambda: 0))
-        bin_dir = os.path.join(os.path.dirname(file_path), 'bin')
-        Polygon3_local = f'Polygon3 @ file://{bin_dir}/Polygon3-3.0.8-cp37-cp37m-win_amd64.whl'
-        Polygon3_git = 'Polygon3 @ https://github.com/QuTech-Delft/qtt/bin/Polygon3-3.0.8-cp37-cp37m-win_amd64.whl'
-        Polygon3 = Polygon3_local
-    else:
-        Polygon3 = 'Polygon3'
-    install_requires.append(Polygon3)
 
 rtd_requires = [
     'sphinx>=1.7', 'sphinx_rtd_theme', 'nbsphinx', 'sphinx-automodapi'
@@ -78,8 +64,7 @@ setup(name='qtt',
       license='MIT',
       package_dir={'': 'src'},
       packages=find_packages(where='./src', exclude=["*tests*"]),
-      data_files=[('bin',
-                  ['bin/Polygon3-3.0.8-cp37-cp37m-win_amd64.whl'])],
+      data_files=[],
       install_requires=install_requires,
       tests_require=tests_require,
       extras_require=extras_require,

--- a/src/qtt/__init__.py
+++ b/src/qtt/__init__.py
@@ -85,8 +85,6 @@ check_version('0.1', 'redis', optional=True)
 check_version('0.8.0', qcodes)
 check_version('0.2', 'qupulse')
 
-check_version('3.0', 'Polygon', install_message="use command 'pip install Polygon3' to install the package")
-
 # %% Load often used constructions
 
 

--- a/src/qtt/gui/dataviewer.py
+++ b/src/qtt/gui/dataviewer.py
@@ -393,7 +393,7 @@ class DataViewer(QtWidgets.QMainWindow):
     def get_plot_parameter(self):
         ''' Return parameter to be plotted '''
         param_name = self.outCombo.currentText()
-        if param_name is not '':
+        if param_name != '':
             return param_name
         parameters = self.dataset.arrays.keys()
         if self.default_parameter in parameters:

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -645,6 +645,7 @@ def directionMean(vec):
 
     """
     vec = np.array(vec)
+
     def dist(a, vec):
         phi = np.arctan2(vec[:, 0], vec[:, 1])
         x = a - phi
@@ -1135,39 +1136,36 @@ def polyarea(p):
     return 0.5 * abs(sum(x0 * y1 - x1 * y0 for ((x0, y0), (x1, y1)) in polysegments(p)))
 
 
-def polyintersect(x1 : np.ndarray, x2 : np.ndarray) -> np.ndarray:
-        """ Calcualte intersection of two polygons
+def polyintersect(x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+    """ Calcualte intersection of two polygons
 
-        Args:
-            x1: First polygon. Shape is (N, 2) with N the number of vertices
-            x2: Second polygon
-        Returns:
-            Intersection of both polygons
+    Args:
+        x1: First polygon. Shape is (N, 2) with N the number of vertices
+        x2: Second polygon
+    Returns:
+        Intersection of both polygons
 
-        Raises:
-            Exception is the intersection consists of multiple polygons
+    Raises:
+        Exception is the intersection consists of multiple polygons
 
-        >>> x1=np.array([(0, 0), (1, 1), (1, 0)] )
-        >>> x2=np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
-        >>> x=polyintersect(x1, x2)
-        >>> _=plt.figure(10); plt.clf()
-        >>> plotPoints(x1.T, '.:r' )
-        >>> plotPoints(x2.T, '.:b' )
-        >>> plotPoints(x.T, '.-g' , linewidth=2)
-        """
+    >>> x1=np.array([(0, 0), (1, 1), (1, 0)] )
+    >>> x2=np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
+    >>> x=polyintersect(x1, x2)
+    >>> _=plt.figure(10); plt.clf()
+    >>> plotPoints(x1.T, '.:r' )
+    >>> plotPoints(x2.T, '.:b' )
+    >>> plotPoints(x.T, '.-g' , linewidth=2)
+    """
 
-        p1 = shapely.geometry.Polygon(x1)
-        p2 = shapely.geometry.Polygon(x2)
-        p = p1.intersection(p2)
-        if p.is_empty:
-            return np.zeros((0, 2))
-        if isinstance(p, shapely.geometry.multipolygon.MultiPolygon):
-            raise Exception('intersection of polygons is not a simple polygon')
-        x = np.array(p.exterior.coords)
-        if len(x)>1:
-            if np.all(x[0]==x[-1]):
-                x=x[:-1, ...]
-        return x
+    p1 = shapely.geometry.Polygon(x1)
+    p2 = shapely.geometry.Polygon(x2)
+    p = p1.intersection(p2)
+    if p.is_empty:
+        return np.zeros((0, 2))
+    if isinstance(p, shapely.geometry.multipolygon.MultiPolygon):
+        raise Exception('intersection of polygons is not a simple polygon')
+    x = np.array(p.exterior.coords)
+    return x
 
 
 # %%
@@ -1210,7 +1208,7 @@ def enlargelims(factor=1.05):
 
     """
     if isinstance(factor, float):
-        factor=[factor]
+        factor = [factor]
     xl = plt.xlim()
     d = (factor[0] - 1) * (xl[1] - xl[0]) / 2
     xl = (xl[0] - d, xl[1] + d)
@@ -1679,7 +1677,7 @@ class plotCallback:
             scale = [1 / (1e-8 + np.ptp(xdata)), 1 / (1e-8 + np.ptp(ydata))]
         self.scale = scale
         if verbose:
-               print(f'plotCallback: scale {scale}')
+            print(f'plotCallback: scale {scale}')
         self.connection_ids = []
 
     def __call__(self, event):
@@ -1697,7 +1695,7 @@ class plotCallback:
                 xdata = np.array(self.xdata)
 
                 if isinstance(xdata[0], numpy.datetime64):
-                    xdata=matplotlib.dates.date2num(xdata)
+                    xdata = matplotlib.dates.date2num(xdata)
 
                 ydata = np.array(self.ydata)
                 pt = np.array([event.xdata, event.ydata])
@@ -1705,7 +1703,7 @@ class plotCallback:
                 dd = xx - pt
                 dd = np.multiply(np.array(self.scale).reshape((1, 2)), dd)
                 d = np.linalg.norm(dd, axis=1)
-                d[np.isnan(d)]=np.inf
+                d[np.isnan(d)] = np.inf
                 idx = np.argmin(d)
                 distance = d[idx]
                 if self.verbose:
@@ -1727,6 +1725,7 @@ class plotCallback:
         cid = fig.canvas.mpl_connect('button_press_event', self)
         self.connection_ids.append(cid)
         return cid
+
 
 def cfigure(*args, **kwargs):
     """ Create Matplotlib figure with copy to clipboard functionality

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1146,7 +1146,7 @@ def polyintersect(x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
         Intersection of both polygons
 
     Raises:
-        Exception is the intersection consists of multiple polygons
+        ValueError if the intersection consists of multiple polygons
 
     >>> x1=np.array([(0, 0), (1, 1), (1, 0)] )
     >>> x2=np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
@@ -1163,9 +1163,9 @@ def polyintersect(x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
     if p.is_empty:
         return np.zeros((0, 2))
     if isinstance(p, shapely.geometry.multipolygon.MultiPolygon):
-        raise Exception('intersection of polygons is not a simple polygon')
-    x = np.array(p.exterior.coords)
-    return x
+        raise ValueError('intersection of polygons is not a simple polygon')
+    intersection_polygon = np.array(p.exterior.coords)
+    return intersection_polygon
 
 
 # %%

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1135,7 +1135,7 @@ def polyarea(p):
     return 0.5 * abs(sum(x0 * y1 - x1 * y0 for ((x0, y0), (x1, y1)) in polysegments(p)))
 
 
-def polyintersect(x1 : np.ndaray, x2 : np.ndarray) -> np.ndarray:
+def polyintersect(x1 : np.ndarray, x2 : np.ndarray) -> np.ndarray:
         """ Calcualte intersection of two polygons
 
         Args:
@@ -1958,7 +1958,7 @@ def robustCost(x, thr, method='L1'):
     """
     if thr is None:
         return x
-    if thr is 'auto':
+    if thr == 'auto':
         ax = np.abs(x)
         thr = np.percentile(ax, 95.)
         p50 = np.percentile(ax, 50)

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1137,7 +1137,7 @@ def polyarea(p):
 
 
 def polyintersect(x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
-    """ Calcualte intersection of two polygons
+    """ Calculate intersection of two polygons
 
     Args:
         x1: First polygon. Shape is (N, 2) with N the number of vertices

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -39,7 +39,7 @@ import numpy as np
 import scipy.io
 import scipy.ndimage.morphology as morphology
 import scipy.ndimage.filters as filters
-import shapely
+import shapely.geometry
 
 __version__ = '0.7.0'
 
@@ -1144,6 +1144,9 @@ def polyintersect(x1 : np.ndarray, x2 : np.ndarray) -> np.ndarray:
         Returns:
             Intersection of both polygons
 
+        Raises:
+            Exception is the intersection consists of multiple polygons
+
         >>> x1=np.array([(0, 0), (1, 1), (1, 0)] )
         >>> x2=np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
         >>> x=polyintersect(x1, x2)
@@ -1158,7 +1161,12 @@ def polyintersect(x1 : np.ndarray, x2 : np.ndarray) -> np.ndarray:
         p = p1.intersection(p2)
         if p.is_empty:
             return np.zeros((0, 2))
+        if isinstance(p, shapely.geometry.multipolygon.MultiPolygon):
+            raise Exception('intersection of polygons is not a simple polygon')
         x = np.array(p.exterior.coords)
+        if len(x)>1:
+            if np.all(x[0]==x[-1]):
+                x=x[:-1, ...]
         return x
 
 

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -34,18 +34,12 @@ import logging
 import pkgutil
 from functools import wraps
 
+import numpy
 import numpy as np
 import scipy.io
-import numpy
 import scipy.ndimage.morphology as morphology
 import scipy.ndimage.filters as filters
-
-
-try:
-    import Polygon as polygon3
-except ImportError:
-    polygon3 = None
-    import shapely
+import shapely
 
 __version__ = '0.7.0'
 
@@ -1141,58 +1135,30 @@ def polyarea(p):
     return 0.5 * abs(sum(x0 * y1 - x1 * y0 for ((x0, y0), (x1, y1)) in polysegments(p)))
 
 
-if polygon3 is None:
-    def polyintersect(x1 : np.ndaray, x2 : np.ndarray) -> np.ndarray:
-            """ Calcualte intersection of two polygons
-
-            Args:
-                x1: First polygon. Shape is (N, 2) with N the number of vertices
-                x2: Second polygon
-            Returns:
-                Intersection of both polygons
-
-            >>> x1=np.array([(0, 0), (1, 1), (1, 0)] )
-            >>> x2=np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
-            >>> x=polyintersect(x1, x2)
-            >>> _=plt.figure(10); plt.clf()
-            >>> plotPoints(x1.T, '.:r' )
-            >>> plotPoints(x2.T, '.:b' )
-            >>> plotPoints(x.T, '.-g' , linewidth=2)
-            """
-
-            p1 = shapely.geometry.Polygon(x1)
-            p2 = shapely.geometry.Polygon(x2)
-            p = p1.intersection(p2)
-            if p.is_empty:
-                return np.zeros((0, 2))
-            x = np.array(p.exterior.coords)
-            return x
-else:
-    def polyintersect(x1, x2):
-        """ Intersection of two polygons
+def polyintersect(x1 : np.ndaray, x2 : np.ndarray) -> np.ndarray:
+        """ Calcualte intersection of two polygons
 
         Args:
-            x1 (array): First polygon
-            x2 (array): Second polygon
+            x1: First polygon. Shape is (N, 2) with N the number of vertices
+            x2: Second polygon
         Returns:
-            Array with points of the intersection
-
-       Example:
+            Intersection of both polygons
 
         >>> x1=np.array([(0, 0), (1, 1), (1, 0)] )
         >>> x2=np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
         >>> x=polyintersect(x1, x2)
         >>> _=plt.figure(10); plt.clf()
-        >>> plotPoints(x1.T, '.-r' )
-        >>> plotPoints(x2.T, '.-b' )
+        >>> plotPoints(x1.T, '.:r' )
+        >>> plotPoints(x2.T, '.:b' )
         >>> plotPoints(x.T, '.-g' , linewidth=2)
-
         """
-        p1 = polygon3.Polygon(x1)
-        p2 = polygon3.Polygon(x2)
-        p = p1 & p2
-        x = np.array(p)
-        x = x.reshape((-1, 2))
+
+        p1 = shapely.geometry.Polygon(x1)
+        p2 = shapely.geometry.Polygon(x2)
+        p = p1.intersection(p2)
+        if p.is_empty:
+            return np.zeros((0, 2))
+        x = np.array(p.exterior.coords)
         return x
 
 

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -3,7 +3,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import qtt.pgeometry as pgeometry
 from qtt.pgeometry import point_in_polygon, points_in_polygon
-from Polygon.cPolygon import Error as PolygonError
 
 
 class TestPGeometry(unittest.TestCase):

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -71,7 +71,7 @@ class TestPolygonGeometry(unittest.TestCase):
         x1 = np.array([(0, 0), (1, 1), (1, 0)])
         x2 = np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
         intersection_polygon = pgeometry.polyintersect(x1, x2)
-        self.assertEqual(3, len(intersection_polygon))
+        self.assertEqual(4, len(intersection_polygon))
         self.assertEqual(0.25, np.abs(pgeometry.polyarea(intersection_polygon)))
 
     def test_polyintersect_empty_intersection(self):
@@ -108,7 +108,7 @@ class TestPolygonGeometry(unittest.TestCase):
         x2 = np.array([(delta, 0), (5, 5), (-5, 5), (-delta, 0), (-5, -5), (5, -5), (delta, 0)])
         intersection_polygon = pgeometry.polyintersect(x1, x2)
 
-        self.assertEqual(intersection_polygon.shape, (10, 2))
+        self.assertEqual(intersection_polygon.shape, (11, 2))
         self.assertEqual(np.abs(pgeometry.polyarea(intersection_polygon)), 31 / 9)
 
     def test_geometry(self, fig=None):

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -27,12 +27,12 @@ class TestGeometryOperations(unittest.TestCase):
             self.assertAlmostEqual(Rx[2, 1], np.sin(phi))
 
     def test_pg_scaling(self):
-        H = pgeometry.pg_scaling([1,2])
-        np.testing.assert_array_equal(H, np.diag([1,2,1]))
+        H = pgeometry.pg_scaling([1, 2])
+        np.testing.assert_array_equal(H, np.diag([1, 2, 1]))
         H = pgeometry.pg_scaling([2], [1])
-        np.testing.assert_array_equal(H, np.array([[2,-1],[0,1.]]) )
+        np.testing.assert_array_equal(H, np.array([[2, -1], [0, 1.]]))
         with self.assertRaises(ValueError):
-            pgeometry.pg_scaling([1], [1,2])
+            pgeometry.pg_scaling([1], [1, 2])
 
     def test_pg_rotation2H(self):
         R = pgeometry.pg_rotx(0.12)
@@ -51,20 +51,21 @@ class TestGeometryOperations(unittest.TestCase):
         np.testing.assert_array_almost_equal(Hs @ Ha @ Hp, R)
 
     def test_directionMean(self):
-        directions = [[1,0],[1,.1], [1,-.1]]
+        directions = [[1, 0], [1, .1], [1, -.1]]
         angle = pgeometry.directionMean(directions)
         angle = np.mod(angle, np.pi)
-        self.assertAlmostEqual(angle, np.pi/2)
+        self.assertAlmostEqual(angle, np.pi / 2)
 
-        directions = [[1,0],[-1,0]]
+        directions = [[1, 0], [-1, 0]]
         angle = pgeometry.directionMean(directions)
         angle = np.mod(angle, np.pi)
-        self.assertAlmostEqual(angle, np.pi/2)
+        self.assertAlmostEqual(angle, np.pi / 2)
+
 
 class TestPolygonGeometry(unittest.TestCase):
 
     def assertEmptyPolygon(self, polygon):
-        self.assertTrue(len(polygon)==0)
+        self.assertTrue(len(polygon) == 0)
 
     def test_polyintersect(self):
         x1 = np.array([(0, 0), (1, 1), (1, 0)])
@@ -75,7 +76,7 @@ class TestPolygonGeometry(unittest.TestCase):
 
     def test_polyintersect_empty_intersection(self):
         x1 = np.array([(0, 0), (1, 1), (1, 0)])
-        x2 = 100+np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
+        x2 = 100 + np.array([(1, 0), (1.5, 1.5), (.5, 0.5)])
         intersection_polygon = pgeometry.polyintersect(x1, x2)
         self.assertEmptyPolygon(intersection_polygon)
 
@@ -89,11 +90,26 @@ class TestPolygonGeometry(unittest.TestCase):
         x1 = np.array([(0, 0)])
         x2 = np.array([(1, 0), (1.5, 1.5)])
 
-        try:
+        with self.assertRaises(ValueError):
             intersection_polygon = pgeometry.polyintersect(x1, x2)
-            self.assertEmptyPolygon(intersection_polygon)
-        except PolygonError as ex: # the assertRaises does not work due to the ctypes error message
-            self.assertIn('Invalid polygon or contour for operation', str(ex))
+
+    def test_multi_polygon_intersection(self):
+        delta = .42
+        shift = 1.7
+        x1 = np.array([(-1, -1), (1, -1), (1, 1), (-1, 1)]) + np.array([shift, 0])
+        x2 = np.array([(delta, 0), (5, 5), (-5, 5), (-delta, 0), (-5, -5), (5, -5), (delta, 0)])
+
+        with self.assertRaises(Exception):
+            polyintersect(x1, x2)
+
+    def test_non_convex_intersection(self):
+        delta = .5
+        x1 = np.array([(-1, -1), (1, -1), (1, 1), (-1, 1)])
+        x2 = np.array([(delta, 0), (5, 5), (-5, 5), (-delta, 0), (-5, -5), (5, -5), (delta, 0)])
+        intersection_polygon = pgeometry.polyintersect(x1, x2)
+
+        self.assertEqual(intersection_polygon.shape, (10, 2))
+        self.assertEqual(np.abs(pgeometry.polyarea(intersection_polygon)), 31 / 9)
 
     def test_geometry(self, fig=None):
         im = np.zeros((200, 100, 3))
@@ -127,5 +143,3 @@ class TestPolygonGeometry(unittest.TestCase):
         self.assertTrue(point_in_polygon([1, 1], pp) == 1)
         self.assertTrue(point_in_polygon([-1, 1], pp) == -1)
         self.assertTrue(np.all(points_in_polygon(np.array([[-1, 1], [1, 1], [.5, .5]]), pp) == np.array([-1, 1, 1])))
-
-

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -99,7 +99,7 @@ class TestPolygonGeometry(unittest.TestCase):
         x2 = np.array([(delta, 0), (5, 5), (-5, 5), (-delta, 0), (-5, -5), (5, -5), (delta, 0)])
 
         with self.assertRaises(Exception):
-            polyintersect(x1, x2)
+            intersection_polygon = pgeometry.polyintersect(x1, x2)
 
     def test_non_convex_intersection(self):
         delta = .5

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -98,7 +98,7 @@ class TestPolygonGeometry(unittest.TestCase):
         x1 = np.array([(-1, -1), (1, -1), (1, 1), (-1, 1)]) + np.array([shift, 0])
         x2 = np.array([(delta, 0), (5, 5), (-5, 5), (-delta, 0), (-5, -5), (5, -5), (delta, 0)])
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             intersection_polygon = pgeometry.polyintersect(x1, x2)
 
     def test_non_convex_intersection(self):


### PR DESCRIPTION
The depencency on `Polygon3` was hard to maintain over different python versions. `shapely` is better supported, at the cost of a slower implementation