### PR TITLE
fix for numpy deprecation

### DIFF
--- a/src/qtt/dataset_processing.py
+++ b/src/qtt/dataset_processing.py
@@ -183,12 +183,12 @@ def _slice_dataset(dataset: DataSet, slice_objects: Sequence[slice], output_para
         print(f'slice_dataset: dimension {scan_dimension} slice_objects {slice_objects}')
 
     if is_1d_dataset:
-        signal_window = zarray[slice_objects]
+        signal_window = zarray[tuple(slice_objects)]
         dataset_window = qtt.data.makeDataSet1Dplain(yarray.name, yarray[slice_objects[0]], yname=output_parameter_name,
                                                      y=signal_window, xunit=yarray.unit, yunit=zarray.unit)
     elif is_2d_dataset:
         xarray = set_arrays[1]
-        signal_window = zarray[slice_objects]
+        signal_window = zarray[tuple(slice_objects)]
         dataset_window = qtt.data.makeDataSet2Dplain(xarray.name, xarray[0][slice_objects[1]], yarray.name,
                                                      yarray[slice_objects[0]], zname=output_parameter_name,
                                                      z=signal_window, xunit=xarray.unit, yunit=yarray.unit,


### PR DESCRIPTION
A minimal example is:
```
import qtt
dataset = qtt.data.load_example_dataset('frequency_rabi_scan.json')
qtt.dataset_processing._slice_dataset(dataset, [slice(0, 4)], output_parameter_name=None, copy_metadata=True)
```
The warning message generated is
```
c:\projects\qcodes\qcodes\data\data_array.py:344: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  return self.ndarray[loop_indices]
```