### PR TITLE
Remove legacy requirement for scipy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ tests_require = ['coverage', 'jupyter', 'mypy', 'pytest']
 install_requires = [
     'apscheduler', 'attrs', 'dulwich', 'h5py<3.0', 'hickle', 'IPython>=0.1', 'jupyter', 'lmfit', 'matplotlib>=3.0',
     'numdifftools', 'numpy>=1.15', 'opencv-python', 'PyQt5', 'pyqtgraph', 'pyvisa', 'pyzmqrpc', 'qcodes>=0.17.0',
-    'qcodes-contrib-drivers', 'qilib', 'qtpy', 'qupulse', 'redis', 'scipy>=0.18', 'scikit-image',
+    'qcodes-contrib-drivers', 'qilib', 'qtpy', 'qupulse', 'redis', 'scipy', 'scikit-image',
     'shapely', 'sympy<1.7'
 ] + tests_require
 


### PR DESCRIPTION
Scipy 0.18 was released in 2016. We remove the requirement because it causes problems in other builds.

![image](https://user-images.githubusercontent.com/17724047/108637653-d8b5c780-748b-11eb-8817-71224e6e7030.png)
