### PR TITLE
[DEM-NNN] enforce decay time to be positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 'elzerman_detuning_scan/2019-05-28_11-39-39_qtt_generic.json' renamed to 'elzerman_detuning_scan'
   - 'misc/P5_y_P5_x.dat' renamed to 'charge_stability_diagram_dac_vs_awg'
   - '2018-08-31/19-05-18_qtt_save_segments' renamed to 'rts_signal'
+- The decay time in the Gauss-Ramsey fit is now always positive (#754)
 
 ### Removed
 - Support for python 3.6 and lower is removed.

--- a/src/qtt/algorithms/functions.py
+++ b/src/qtt/algorithms/functions.py
@@ -375,6 +375,7 @@ def fit_gauss_ramsey(x_data, y_data, weight_power=None, maxiter=None, maxfun=500
         initial_parameters = initial_params
     lmfit_model = Model(gauss_ramsey_model)
     lmfit_model.set_param_hint('amplitude', min=0)
+    lmfit_model.set_param_hint('decay_time', min=0)
     lmfit_result = lmfit_model.fit(y_data, x=x_data, **dict(zip(lmfit_model.param_names, initial_parameters)),
                                    verbose=verbose >= 2, weights=weights)
 


### PR DESCRIPTION
The decay time could be fitted negative in the gauss-ramsey fit. This has no physical meaning. In particular it is not an increasing signal, because of the square in the `gauss_ramsey` method.
We add a contraint to the `lmfit` fitter to make the decay time positive.