### PR TITLE
Remove legacy numpy check

### DIFF
--- a/src/qtt/algorithms/markov_chain.py
+++ b/src/qtt/algorithms/markov_chain.py
@@ -13,12 +13,7 @@ import itertools
 
 
 def _solve_least_squares(a, b):
-    from distutils.version import StrictVersion
-    if StrictVersion(np.__version__) < StrictVersion('1.14.0'):
-        # legacy numpy versions
-        rcond = -1
-    else:
-        rcond = None
+    rcond = None
     solution = np.linalg.lstsq(a, b, rcond=rcond)[0]
     return solution
 

--- a/src/qtt/algorithms/misc.py
+++ b/src/qtt/algorithms/misc.py
@@ -134,11 +134,7 @@ def polyfit2d(x, y, z, order=3):
     ij = itertools.product(range(order + 1), range(order + 1))
     for k, (i, j) in enumerate(ij):
         G[:, k] = x**i * y**j
-    rcond = None
-    from distutils.version import StrictVersion
-    if StrictVersion(np.__version__) < StrictVersion('1.14.0'):
-        rcond = -1
-    m, _, _, _ = np.linalg.lstsq(G, z, rcond=rcond)
+    m, _, _, _ = np.linalg.lstsq(G, z, rcond=None)
     return m
 
 


### PR DESCRIPTION
The check gives errors on my system and is not required any more since we require `numpy>=1.15`

@QFer 