### PR TITLE
Add method to combine legends of multiple matplotlib axis objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add measure_time context for measuring exection time (#765)
-
+- Add method to combine legends of multiple matplotlib axes (#782)
 ### Changed
 
 - Improve sine fitting (#762)

--- a/src/qtt/utilities/visualization.py
+++ b/src/qtt/utilities/visualization.py
@@ -7,12 +7,12 @@ import numpy as np
 import qtt.algorithms.functions
 
 
-def combine_legends(axis_list: List[matplotlib.axes.Axes], target_ax: Optional[matplotlib.axes.Axes]):
+def combine_legends(axis_list: List[matplotlib.axes.Axes], target_ax: Optional[matplotlib.axes.Axes] = None):
     """ Combine legends of a list of matplotlib axis objects into a single legend
 
     Args:
         axis_list: List of matplotlib axis containing legends
-        target_ax: Axis to add the combined legend to
+        target_ax: Axis to add the combined legend to. If None, use the first axis from the `axis_list`
 
     Example:
         import matplotlib.pyplot as plt
@@ -29,15 +29,17 @@ def combine_legends(axis_list: List[matplotlib.axes.Axes], target_ax: Optional[m
     labels: List[Any] = []
     for ax in axis_list:
         lines1, labels1 = ax.get_legend_handles_labels()
-        lines = lines + lines1
-        labels = labels + labels1
+        lines.extend(lines1)
+        labels.extend(labels1)
         legend = ax.get_legend()
         if legend is not None:
             legend.remove()
 
     if target_ax is None:
-        target_ax = axis_list[0]
-    target_ax.legend(lines, labels)
+        target_ax = next(iter(axis_list), None)
+
+    if target_ax is not None:
+        target_ax.legend(lines, labels)
 
 
 def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None) -> Any:

--- a/src/qtt/utilities/visualization.py
+++ b/src/qtt/utilities/visualization.py
@@ -1,9 +1,43 @@
-from typing import Optional, Any, Union
+from typing import Any, List, Optional, Union
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
 import qtt.algorithms.functions
+
+
+def combine_legends(axis_list: List[matplotlib.axes.Axes], target_ax: Optional[matplotlib.axes.Axes]):
+    """ Combine legends of a list of matplotlib axis objects into a single legend
+
+    Args:
+        axis_list: List of matplotlib axis containing legends
+        target_ax: Axis to add the combined legend to
+
+    Example:
+        import matplotlib.pyplot as plt
+        ax1=plt.gca()
+        plt.plot([1,2,3], [.1,.2,.3], '.b', label='X')
+        plt.legend()
+        ax2=ax1.twinx()
+        ax2.plot([1,2,3], [1, 2, 3], '-r', label='miliX' )
+        plt.legend()
+        combine_legends([ax1, ax2])
+
+    """
+    lines: List[Any] = []
+    labels: List[Any] = []
+    for ax in axis_list:
+        lines1, labels1 = ax.get_legend_handles_labels()
+        lines = lines + lines1
+        labels = labels + labels1
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.remove()
+
+    if target_ax is None:
+        target_ax = axis_list[0]
+    target_ax.legend(lines, labels)
 
 
 def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None) -> Any:

--- a/src/tests/unittests/utilities/test_visualization.py
+++ b/src/tests/unittests/utilities/test_visualization.py
@@ -18,6 +18,14 @@ class TestUtilities(unittest.TestCase):
         qtt.utilities.visualization.combine_legends([ax1, ax2], target_ax=ax2)
         plt.close(1)
 
+    def test_combine_legends_empty_input(self):
+        plt.figure(1)
+        plt.clf()
+        ax1 = plt.gca()
+        ax1.plot([1, 2], [3, 4], label='a')
+        qtt.utilities.visualization.combine_legends([], target_ax=ax1)
+        plt.close(1)
+
 
 class TestVerticalHorizontalLine(unittest.TestCase):
 

--- a/src/tests/unittests/utilities/test_visualization.py
+++ b/src/tests/unittests/utilities/test_visualization.py
@@ -1,7 +1,22 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+
+import matplotlib.pyplot as plt
 
 import qtt.utilities.visualization
+
+
+class TestUtilities(unittest.TestCase):
+
+    def test_combine_legends(self):
+        plt.figure(1)
+        plt.clf()
+        ax1 = plt.gca()
+        ax1.plot([1, 2], [3, 4], label='a')
+        ax2 = ax1.twinx()
+        ax2.plot([1, 2], [4, 3], 'r', label='b')
+        qtt.utilities.visualization.combine_legends([ax1, ax2], target_ax=ax2)
+        plt.close(1)
 
 
 class TestVerticalHorizontalLine(unittest.TestCase):


### PR DESCRIPTION
Add method to combine legends of multiple matplotlib axis objects into a single legend. This can be used for example with creating plots with a dual x-axis (e.g. `twinx`)