### PR TITLE
Deprecate methods for storing instruments with configparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecated instrument adapters. Deprecated post-processing tools in qtt.measurements.post_processing (#777)
+- Deprecated methods in qtt.instrument_storage (#783)
+
 ### Fixed
 
 ## \[1.2.3] - 22-3-2021

--- a/src/qtt/instrument_storage.py
+++ b/src/qtt/instrument_storage.py
@@ -1,17 +1,21 @@
 """ Functionality to store instrument data in a configuration file """
-import numpy as np
+import configparser
 import json
 import numbers
-import configparser
+
+import numpy as np
+
 import qtt.utilities.tools
+from qtt.utilities.tools import rdeprecated
 
 
+@rdeprecated(txt='This method will be removed in a future release', expire='Sep 1 2021')
 def save_instrument_configparser(instr, ifile, verbose=1):
     """ Save instrument configuration to configparser structure
 
     Args:
         instr (Instrument): instrument to apply settings to
-        ifile (str): configuration file    
+        ifile (str): configuration file
     """
     jdict = configparser.ConfigParser()
     jdict.read(ifile)
@@ -30,12 +34,13 @@ def save_instrument_configparser(instr, ifile, verbose=1):
         jdict.write(fid)
 
 
+@rdeprecated(txt='This method will be removed in a future release', expire='Sep 1 2021')
 def load_instrument_configparser(instr, ifile, verbose=1):
     """ Load instrument configuration from configparser structure
 
     Args:
         instr (Instrument): instrument to apply settings to
-        ifile (str): configuration file    
+        ifile (str): configuration file
     """
     jdict = configparser.ConfigParser()
     jdict.read(ifile)
@@ -65,6 +70,7 @@ save_instrument = save_instrument_configparser
 
 if __name__ == '__main__':
     import os
+
     from stationV2.tools import V2hardware
     v2hardware = V2hardware(name='v2hardware', server_name=None)
 


### PR DESCRIPTION
Methods are not in active use and there are better alternatives (e.g. in sqt or lls2)