### PR TITLE
Add method to allow plotting to user specified Axes object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add measure_time context for measuring exection time (#765)
 - Add method to combine legends of multiple matplotlib axes (#782)
+- Functionality plot onto a matplotlib Axes object (#785)
+
 ### Changed
 
 - Improve sine fitting (#762)
@@ -77,7 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update docstrings (#718)
 - Add numdifftools to requirements (#726)
 - Add fitting of sine wave (#731)
-- Functionality plot onto a matplotlib Axes object (#785)
 
 ### Changed
 - Prevent tests from writing data to the user directory (#710)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update docstrings (#718)
 - Add numdifftools to requirements (#726)
 - Add fitting of sine wave (#731)
+- Functionality plot onto a matplotlib Axes object (#785)
 
 ### Changed
 - Prevent tests from writing data to the user directory (#710)

--- a/src/qtt/algorithms/allxy.py
+++ b/src/qtt/algorithms/allxy.py
@@ -1,12 +1,14 @@
-from typing import Dict, Any, List, Union, Optional
-import numpy as np
-import matplotlib.pyplot as plt
-from lmfit import Model
+from typing import Any, Dict, List, Optional, Union
 
-from qcodes.data.data_set import DataSet
+import numpy as np
+from lmfit import Model
+from matplotlib.axes import Axes
 from qcodes.data.data_array import DataArray
-from qtt.utilities.visualization import plot_vertical_line
+from qcodes.data.data_set import DataSet
+
 from qtt.algorithms.fitting import extract_lmfit_parameters
+from qtt.utilities.visualization import create_axis, plot_vertical_line
+
 
 def generate_allxy_combinations() -> List[Any]:
     """ Generate all combinations of the AllXY sequence from Reed 2013 """
@@ -89,7 +91,7 @@ def fit_allxy(dataset: DataSet, initial_parameters: Optional[np.ndarray] = None)
     return analysis_results
 
 
-def plot_allxy(dataset: DataSet, result: Dict[str, Any], fig: int = 1, plot_initial_estimate: bool = False):
+def plot_allxy(dataset: DataSet, result: Dict[str, Any], fig: Union[int, Axes] = 1, plot_initial_estimate: bool = False):
     """ Plot the results of an AllXY fit
 
     Args:
@@ -102,29 +104,30 @@ def plot_allxy(dataset: DataSet, result: Dict[str, Any], fig: int = 1, plot_init
     xy_pairs = generate_allxy_combinations()
     x_data = np.arange(21)
 
-    plt.figure(fig)
-    plt.clf()
+    ax = create_axis(fig)
     fitted_parameters = result['fitted_parameters']
     xfine = np.arange(0, 21, 1e-3)
-    plt.plot(xfine, allxy_model(xfine, *fitted_parameters), 'm', label='fitted allxy', alpha=.5)
+    ax.plot(xfine, allxy_model(xfine, *fitted_parameters), 'm', label='fitted allxy', alpha=.5)
 
-    plt.plot(x_data, allxy_data, '.b', label='allxy data')
+    ax.plot(x_data, allxy_data, '.b', label='allxy data')
 
     if plot_initial_estimate:
         p = [0, 0, .5, 0, 1, 0]
-        plt.plot(xfine, allxy_model(xfine, *p), 'c', label='baseline', alpha=.5)
+        ax.plot(xfine, allxy_model(xfine, *p), 'c', label='baseline', alpha=.5)
 
         initial_params = _estimate_allxy_parameters(allxy_data)
-        plt.plot(xfine, allxy_model(xfine, *initial_params), 'g', label='initial estimate', alpha=.35)
+        ax.plot(xfine, allxy_model(xfine, *initial_params), 'g', label='initial estimate', alpha=.35)
 
         initial_parameters = result['initial_parameters']
-        plt.plot(xfine, allxy_model(xfine, *initial_parameters), ':g', label='initial estimate', alpha=.35)
+        ax.plot(xfine, allxy_model(xfine, *initial_parameters), ':g', label='initial estimate', alpha=.35)
 
-    plt.xticks(x_data, [v[0] + "," + v[1] for v in xy_pairs], rotation='vertical')
+    ax.set_xticks(x_data)
+    ax.set_xticklabels([v[0] + "," + v[1] for v in xy_pairs], rotation='vertical')
+
     vl = plot_vertical_line(4.5)
     vl.set_linestyle(':')
     vl = plot_vertical_line(16.5)
     vl.set_linestyle(':')
-    plt.title('AllXY')
+    ax.set_title('AllXY')
 
-    plt.legend()
+    ax.legend()

--- a/src/qtt/algorithms/allxy.py
+++ b/src/qtt/algorithms/allxy.py
@@ -91,13 +91,13 @@ def fit_allxy(dataset: DataSet, initial_parameters: Optional[np.ndarray] = None)
     return analysis_results
 
 
-def plot_allxy(dataset: DataSet, result: Dict[str, Any], fig: Union[int, Axes] = 1, plot_initial_estimate: bool = False):
+def plot_allxy(dataset: DataSet, result: Dict[str, Any], fig: Union[int, Axes, None] = 1, plot_initial_estimate: bool = False):
     """ Plot the results of an AllXY fit
 
     Args:
         dataset: Dataset containing the measurement data
         result: Fitting result of fit_allxy
-        int: Figure handle
+        fig: Figure or axis handle. Is passed on to `get_axis`
         plot_initial_guess: If True, then plot the initial estimate of the model
     """
     allxy_data = _default_measurement_array(dataset)

--- a/src/qtt/algorithms/allxy.py
+++ b/src/qtt/algorithms/allxy.py
@@ -7,7 +7,7 @@ from qcodes.data.data_array import DataArray
 from qcodes.data.data_set import DataSet
 
 from qtt.algorithms.fitting import extract_lmfit_parameters
-from qtt.utilities.visualization import create_axis, plot_vertical_line
+from qtt.utilities.visualization import get_axis, plot_vertical_line
 
 
 def generate_allxy_combinations() -> List[Any]:
@@ -104,7 +104,7 @@ def plot_allxy(dataset: DataSet, result: Dict[str, Any], fig: Union[int, Axes, N
     xy_pairs = generate_allxy_combinations()
     x_data = np.arange(21)
 
-    ax = create_axis(fig)
+    ax = get_axis(fig)
     fitted_parameters = result['fitted_parameters']
     xfine = np.arange(0, 21, 1e-3)
     ax.plot(xfine, allxy_model(xfine, *fitted_parameters), 'm', label='fitted allxy', alpha=.5)

--- a/src/qtt/algorithms/functions.py
+++ b/src/qtt/algorithms/functions.py
@@ -1,16 +1,18 @@
 """ Mathematical functions and models """
 
+from typing import Union
+
+import matplotlib.pyplot as plt
 import numpy as np
 import scipy
 import scipy.constants
-from typing import Union
-import matplotlib.pyplot as plt
 from lmfit import Model
+from matplotlib.axes import Axes
 
 import qtt.pgeometry
 import qtt.utilities.tools
-from qtt.utilities.visualization import plot_vertical_line
 from qtt.algorithms.generic import subpixelmax
+from qtt.utilities.visualization import create_axis, plot_vertical_line
 
 
 def gaussian(x, mean, std, amplitude=1, offset=0):
@@ -392,7 +394,7 @@ def fit_gauss_ramsey(x_data, y_data, weight_power=None, maxiter=None, maxfun=500
     return result_dict['fitted_parameters'], result_dict
 
 
-def plot_gauss_ramsey_fit(x_data, y_data, fit_parameters, fig):
+def plot_gauss_ramsey_fit(x_data, y_data, fit_parameters, fig: Union[int, Axes]):
     """ Plot Gauss Ramsey fit
 
     Args:
@@ -404,14 +406,13 @@ def plot_gauss_ramsey_fit(x_data, y_data, fit_parameters, fig):
     freq_fit = abs(fit_parameters[2] * 1e-6)
     t2star_fit = fit_parameters[1] * 1e6
 
-    plt.figure(fig)
-    plt.clf()
-    plt.plot(x_data * 1e6, y_data, 'o', label='Data')
-    plt.plot(test_x * 1e6, gauss_ramsey(test_x, fit_parameters), label='Fit')
-    plt.title(r'Gauss Ramsey fit: %.2f MHz / $T_2^*$: %.1f $\mu$s' % (freq_fit, t2star_fit))
-    plt.xlabel(r'time ($\mu$s)')
-    plt.ylabel('Spin-up probability')
-    plt.legend()
+    ax = create_axis(fig)
+    ax.plot(x_data * 1e6, y_data, 'o', label='Data')
+    ax.plot(test_x * 1e6, gauss_ramsey(test_x, fit_parameters), label='Fit')
+    ax.set_title(r'Gauss Ramsey fit: %.2f MHz / $T_2^*$: %.1f $\mu$s' % (freq_fit, t2star_fit))
+    ax.set_xlabel(r'time ($\mu$s)')
+    ax.set_ylabel('Spin-up probability')
+    ax.legend()
 
 
 def linear_function(x, a, b):

--- a/src/qtt/algorithms/functions.py
+++ b/src/qtt/algorithms/functions.py
@@ -12,7 +12,7 @@ from matplotlib.axes import Axes
 import qtt.pgeometry
 import qtt.utilities.tools
 from qtt.algorithms.generic import subpixelmax
-from qtt.utilities.visualization import create_axis, plot_vertical_line
+from qtt.utilities.visualization import get_axis, plot_vertical_line
 
 
 def gaussian(x, mean, std, amplitude=1, offset=0):
@@ -394,19 +394,20 @@ def fit_gauss_ramsey(x_data, y_data, weight_power=None, maxiter=None, maxfun=500
     return result_dict['fitted_parameters'], result_dict
 
 
-def plot_gauss_ramsey_fit(x_data, y_data, fit_parameters, fig: Union[int, Axes]):
+def plot_gauss_ramsey_fit(x_data, y_data, fit_parameters, fig: Union[int, Axes, None]):
     """ Plot Gauss Ramsey fit
 
     Args:
         x_data: Input array with time variable (in seconds)
         y_data: Input array with signal
         fit_parameters: Result of fit_gauss_ramsey (fitting units in seconds)
+        fig: Figure or axis handle. Is passed to `get_axis`
     """
     test_x = np.linspace(0, np.max(x_data), 200)
     freq_fit = abs(fit_parameters[2] * 1e-6)
     t2star_fit = fit_parameters[1] * 1e6
 
-    ax = create_axis(fig)
+    ax = get_axis(fig)
     ax.plot(x_data * 1e6, y_data, 'o', label='Data')
     ax.plot(test_x * 1e6, gauss_ramsey(test_x, fit_parameters), label='Fit')
     ax.set_title(r'Gauss Ramsey fit: %.2f MHz / $T_2^*$: %.1f $\mu$s' % (freq_fit, t2star_fit))

--- a/src/qtt/utilities/visualization.py
+++ b/src/qtt/utilities/visualization.py
@@ -48,7 +48,7 @@ def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: O
     """
     if ax is None:
         ax = plt.gca()
-    vline = plt.axhline(x, label=label)
+    vline = ax.axhline(x, label=label)
     vline.set_alpha(alpha)
     vline.set_color(color)
     vline.set_linestyle('--')

--- a/src/qtt/utilities/visualization.py
+++ b/src/qtt/utilities/visualization.py
@@ -9,13 +9,14 @@ from matplotlib.figure import Figure
 import qtt.algorithms.functions
 
 
-def create_axis(handle: Union[int, Axes, Figure, None]):
-    """ Create matplotlib axis object
+def get_axis(handle: Union[int, Axes, Figure, None]) -> Axes:
+    """ Create or return matplotlib axis object
 
     Args:
         handle: Specification of how to obtain the axis object. For an integer, generate a new figure.
             For an Axis object, return the handle.
             For a Figure, return the default axis of the figure.
+            For None, use the matplotlib current axis.
     Returns:
         Axis object
     """
@@ -69,7 +70,8 @@ def combine_legends(axis_list: List[matplotlib.axes.Axes], target_ax: Optional[m
         target_ax.legend(lines, labels)
 
 
-def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None, ax: Optional[Axes] = None) -> Any:
+def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None,
+                         ax: Optional[Axes] = None) -> Any:
     """ Plot vertical alignment line
 
     Args:

--- a/src/qtt/utilities/visualization.py
+++ b/src/qtt/utilities/visualization.py
@@ -1,12 +1,39 @@
-from typing import Optional, Any, Union
+from typing import Any, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 import qtt.algorithms.functions
 
 
-def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None) -> Any:
+def create_axis(handle: Union[int, Axes, Figure, None]):
+    """ Create matplotlib axis object
+
+    Args:
+        handle: Specification of how to obtain the axis object. For an integer, generate a new figure.
+            For an Axis object, return the handle.
+            For a Figure, return the default axis of the figure.
+    Returns:
+        Axis object
+    """
+    if handle is None:
+        return plt.gca()
+    elif isinstance(handle, Axes):
+        return handle
+    elif isinstance(handle, int):
+        plt.figure(handle)
+        plt.clf()
+        return plt.gca()
+    elif isinstance(handle, Figure):
+        plt.figure(handle)
+        return plt.gca()
+    else:
+        raise NotImplementedError('handle {handle} of type {type(handle)}  is not implemented')
+
+
+def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None, ax: Optional[Axes] = None) -> Any:
     """ Plot vertical alignment line
 
     Args:
@@ -14,9 +41,13 @@ def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: O
         color: Color specification of the line
         alpha: Value to use for the transparency of the line
         label: Label for the line
-    Return:
+        ax: Matplotlib axis handle to plot to. If None, select the default handle
+
+    Returns:
         Handle to the plotted line
     """
+    if ax is None:
+        ax = plt.gca()
     vline = plt.axhline(x, label=label)
     vline.set_alpha(alpha)
     vline.set_color(color)
@@ -24,7 +55,7 @@ def plot_horizontal_line(x: float, color: str = 'c', alpha: float = .5, label: O
     return vline
 
 
-def plot_vertical_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None) -> Any:
+def plot_vertical_line(x: float, color: str = 'c', alpha: float = .5, label: Optional[str] = None, ax: Optional[Axes] = None) -> Any:
     """ Plot vertical alignment line
 
     Args:
@@ -32,11 +63,15 @@ def plot_vertical_line(x: float, color: str = 'c', alpha: float = .5, label: Opt
         color: Color specification of the line
         alpha: Value to use for the transparency of the line
         label: Label for the line
-    Return:
+        ax: Matplotlib axis handle to plot to. If None, select the default handle
+
+    Returns:
         Handle to the plotted line
 
     """
-    vline = plt.axvline(x, label=label)
+    if ax is None:
+        ax = plt.gca()
+    vline = ax.axvline(x, label=label)
     vline.set_alpha(alpha)
     vline.set_color(color)
     vline.set_linestyle('--')

--- a/src/tests/integration/algorithms/test_functions.py
+++ b/src/tests/integration/algorithms/test_functions.py
@@ -1,10 +1,17 @@
 import unittest
+
 import matplotlib.pyplot as plt
 import numpy as np
+
 import qtt
-from qtt.algorithms.functions import gaussian, double_gaussian, exp_function, \
-    fit_gauss_ramsey, gauss_ramsey, cost_exp_decay, logistic, linear_function, Fermi, fit_exp_decay, \
-    _estimate_exp_decay_initial_parameters, plot_gauss_ramsey_fit, estimate_parameters_damped_sine_wave
+from qtt.algorithms.functions import (Fermi,
+                                      _estimate_exp_decay_initial_parameters,
+                                      cost_exp_decay, double_gaussian,
+                                      estimate_parameters_damped_sine_wave,
+                                      exp_function, fit_exp_decay,
+                                      fit_gauss_ramsey, gauss_ramsey, gaussian,
+                                      linear_function, logistic,
+                                      plot_gauss_ramsey_fit)
 
 
 class TestFunctions(unittest.TestCase):
@@ -29,7 +36,7 @@ class TestFunctions(unittest.TestCase):
 
         par_fit_test, _ = fit_gauss_ramsey(x_data * 1e-6, y_data)
 
-        plot_gauss_ramsey_fit(x_data, y_data, par_fit_test, fig=fig)
+        plot_gauss_ramsey_fit(x_data*1e-6, y_data, par_fit_test, fig=fig)
 
     def test_fit_gauss_ramsey_weights(self, fig=123):
         x_data = np.hstack((np.linspace(0, 3 * np.pi, 20), np.linspace(3 * np.pi, 4 * np.pi, 100)))
@@ -50,5 +57,3 @@ class TestFunctions(unittest.TestCase):
             plt.plot(x_data, gauss_ramsey(x_data, fitted_parameters_unweighted), 'b')
             plt.plot(x_data, gauss_ramsey(x_data, fitted_parameters), 'm')
             plt.close(fig)
-
-

--- a/src/tests/unittests/utilities/test_visualization.py
+++ b/src/tests/unittests/utilities/test_visualization.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import qtt.utilities.visualization
 
@@ -8,18 +8,18 @@ class TestVerticalHorizontalLine(unittest.TestCase):
 
     def test_plot_vertical_line(self):
         mock = Mock()
-        with patch('matplotlib.pyplot.axvline', return_value=mock) as mock_axvline:
-            vline = qtt.utilities.visualization.plot_vertical_line(3., color='r', alpha=.1, label='hi')
+        mock_ax = Mock()
+        mock_ax.axvline = Mock(return_value=mock)
+        vline = qtt.utilities.visualization.plot_vertical_line(3., color='r', alpha=.1, label='hi', ax=mock_ax)
 
-            mock_axvline.assert_called_once_with(3., label='hi')
-
+        mock_ax.axvline.assert_called_once_with(3., label='hi')
         self.assertEqual(vline, mock)
 
     def test_plot_horizontal_line(self):
         mock = Mock()
-        with patch('matplotlib.pyplot.axhline', return_value=mock) as mock_axhline:
-            vline = qtt.utilities.visualization.plot_horizontal_line(3., color='r', alpha=.1, label='hi')
+        mock_ax = Mock()
+        mock_ax.axhline = Mock(return_value=mock)
+        vline = qtt.utilities.visualization.plot_horizontal_line(4., color='r', alpha=.1, label='hi', ax=mock_ax)
 
-            mock_axhline.assert_called_once_with(3., label='hi')
-
+        mock_ax.axhline.assert_called_once_with(4., label='hi')
         self.assertEqual(vline, mock)


### PR DESCRIPTION
This PR adds the method `create_axis` that returns a matplotlib `Axes` object to plot to. This allows the qtt plotting methods to plot into a subplot (by passing the appropriate `Axes` object) and not only to a full figure window.

* Add method to `create_axis` to create a matplotlib Axes objects based on a handle
* Update plotting methods to use the new `create_axis` method