### PR TITLE
Use build cache for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+
+cache: pip
+
 matrix:
   include:
   - name: Minimal installation 3.8


### PR DESCRIPTION
The `pip` packages contribute for a large part to the build time. This cache can reduce that time.