### PR TITLE
Replace deprecated functionality from Qiskit upstream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ tests_require = ['coverage', 'jupyter', 'mypy', 'types-redis', 'types-python-dat
 install_requires = [
     'apscheduler', 'attrs', 'dulwich', 'h5py', 'IPython>=0.1', 'jupyter', 'lmfit', 'matplotlib>=3.0',
     'numdifftools', 'numpy>=1.15', 'opencv-python', 'pandas', 'PyQt5', 'pyqtgraph', 'pyvisa', 'pyzmqrpc', 'qcodes>=0.23.0',
-    'qcodes-contrib-drivers', 'qilib', 'qiskit-terra', 'qtpy', 'qupulse', 'redis', 'scipy', 'scikit-image',
+    'qcodes-contrib-drivers', 'qilib', 'qiskit-terra>=0.19', 'qtpy', 'qupulse', 'redis', 'scipy', 'scikit-image',
     'shapely', 'sympy', 'imageio'
 ] + tests_require
 

--- a/src/qtt/qiskit/passes.py
+++ b/src/qtt/qiskit/passes.py
@@ -13,6 +13,7 @@ from qiskit.circuit.library.standard_gates import (CU1Gate, RZZGate, SdgGate,
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit
+from qiskit.dagcircuit.dagnode import DAGInNode, DAGNode, DAGOpNode, DAGOutNode
 from qiskit.transpiler.basepasses import TransformationPass
 
 logger = logging.getLogger(__name__)
@@ -94,17 +95,17 @@ class RemoveDiagonalGatesAfterInput(TransformationPass):
             except StopIteration:
                 continue
 
-            if successor.type == "op" and isinstance(successor.op, diagonal_1q_gates):
+            if isinstance(successor, DAGOpNode) and isinstance(successor.op, diagonal_1q_gates):
                 nodes_to_remove.add(successor)
 
             def valid_predecessor(s):
                 """ Return True of node is valid predecessor for removal """
-                if s.type == 'in':
+                if isinstance(s, DAGInNode):
                     return True
-                if s.type == "op" and isinstance(s.op, Reset):
+                if isinstance(s, DAGOpNode) and isinstance(s.op, Reset):
                     return True
                 return False
-            if successor.type == "op" and isinstance(successor.op, diagonal_2q_gates):
+            if isinstance(successor, DAGOpNode) and isinstance(successor.op, diagonal_2q_gates):
                 predecessors = dag.quantum_predecessors(successor)
                 if all(valid_predecessor(s) for s in predecessors):
                     nodes_to_remove.add(successor)


### PR DESCRIPTION
Replace usage of DAGNode.type which has been deprecated in qiskit. With 0.19 released on pypi the preferred interface is now available via pip.