### PR TITLE
Cleanup mpl2clipboard

### DIFF
--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1600,8 +1600,8 @@ def mpl2clipboard(event=None, verbose: int = 0, fig: Optional[Union[int, plt.Fig
         fig = plt.figure(fig)
     if verbose:
         print('mpl2clipboard: copy figure %s to clipboard' % fig)
-    w, h = fig.canvas.get_width_height()
-    buf = np.fromstring(fig.canvas.tostring_argb(), dtype=np.uint8)
+    w, h = fig.canvas.get_width_height()  # type: ignore
+    buf = np.fromstring(fig.canvas.tostring_argb(), dtype=np.uint8)  # type: ignore
     buf.shape = (h, w, 4)
     im = np.roll(buf, 3, axis=2)
     im = cv2.cvtColor(im, cv2.COLOR_RGB2BGR)

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -21,6 +21,7 @@ Original code:
 
 # %% Load necessary packages
 
+import copy
 import logging
 import math
 import os
@@ -33,7 +34,7 @@ import tempfile
 import time
 import warnings
 from functools import wraps
-from typing import Optional
+from typing import Optional, Union
 
 import numpy
 import numpy as np
@@ -1587,7 +1588,7 @@ except BaseException:
 
 # %% Copy mplimage to clipboard
 
-def mpl2clipboard(event=None, verbose=1, fig=None):
+def mpl2clipboard(event=None, verbose: int = 1, fig: Optional[Union[int, plt.Figure]] = None):
     """ Copy current Matplotlib figure to clipboard
 
     Args:

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1587,56 +1587,31 @@ except BaseException:
 
 # %% Copy mplimage to clipboard
 
-try:
-    _usegtk = 0
-    try:
-        import matplotlib.pyplot
-        _usegtk = 0
-    except BaseException:
-        import pygtk
-        pygtk.require('2.0')
-        import gtk
-        _usegtk = 1
-        pass
+def mpl2clipboard(event=None, verbose=1, fig=None):
+    """ Copy current Matplotlib figure to clipboard
 
-    def mpl2clipboard(event=None, verbose=1, fig=None):
-        """ Copy current Matplotlib figure to clipboard """
-        if verbose:
-            print('copy current Matplotlib figure to clipboard')
-        if fig is None:
-            fig = matplotlib.pyplot.gcf()
-        else:
-            print('mpl2clipboard: figure %s' % fig)
-        w, h = fig.canvas.get_width_height()
-        buf = np.fromstring(fig.canvas.tostring_argb(), dtype=np.uint8)
-        buf.shape = (h, w, 4)
-        im = np.roll(buf, 3, axis=2)
-        im = cv2.cvtColor(im, cv2.COLOR_RGB2BGR)
+    Args:
+        event: Unused argument
+        verbose: Verbosity level
+        fig: Figure handle. If None, select the current figure
+    """
+    if fig is None:
+        fig = matplotlib.pyplot.gcf()
+    elif isinstance(fig, int):
+        fig = plt.figure(fig)
+    if verbose:
+        print('mpl2clipboard: copy figure %s to clipboard' % fig)
+    w, h = fig.canvas.get_width_height()
+    buf = np.fromstring(fig.canvas.tostring_argb(), dtype=np.uint8)
+    buf.shape = (h, w, 4)
+    im = np.roll(buf, 3, axis=2)
+    im = cv2.cvtColor(im, cv2.COLOR_RGB2BGR)
 
-        if _usegtk:
-            r, tmpfile = tempfile.mkstemp(suffix='.png')
-            cv2.imwrite(tmpfile, im)
-            image = gtk.gdk.pixbuf_new_from_file(tmpfile)
-            clipboard = gtk.clipboard_get()
-            clipboard.set_image(image)
-            clipboard.store()
-        else:
-            cb = QtWidgets.QApplication.clipboard()
-            r, tmpfile = tempfile.mkstemp(suffix='.bmp')
-            cv2.imwrite(tmpfile, im)
-            qim = QtGui.QPixmap(tmpfile)
-            cb.setPixmap(qim)
-
-except BaseException:
-    def mpl2clipboard(event=None, verbose=1, fig=None):
-        """ Copy current Matplotlib figure to clipboard
-
-        Dummy implementation
-        """
-        if verbose:
-            print('copy current Matplotlib figure to clipboard not available')
-
-    pass
+    cb = QtWidgets.QApplication.clipboard()
+    r, tmpfile = tempfile.mkstemp(suffix='.bmp')
+    cv2.imwrite(tmpfile, im)
+    qim = QtGui.QPixmap(tmpfile)
+    cb.setPixmap(qim)
 
 
 def addfigurecopy(fig=None):

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1586,7 +1586,7 @@ except BaseException:
 
 # %% Copy mplimage to clipboard
 
-def mpl2clipboard(event=None, verbose: int = 1, fig: Optional[Union[int, plt.Figure]] = None):
+def mpl2clipboard(event=None, verbose: int = 0, fig: Optional[Union[int, plt.Figure]] = None):
     """ Copy current Matplotlib figure to clipboard
 
     Args:

--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -1493,7 +1493,6 @@ def save(pkl_file, *args):
     """
 
     # save data to disk
-    # pdb.set_trace()
     output = open(pkl_file, 'wb')
     pickle.dump(args, output, protocol=2)
     output.close()
@@ -1510,7 +1509,6 @@ def load(pkl_file):
             # if pickle file was saved in python2 we might fix issues with a different encoding
             output = open(pkl_file, 'rb')
             data2 = pickle.load(output, encoding='latin')
-            # pickle.load(pkl_file, fix_imports=True, encoding="ASCII", errors="strict")
             output.close()
         else:
             data2 = None


### PR DESCRIPTION
* Respect `verbose` setting of the method
* Remove check on `gtk`. Since `PyQt5` is a requirement for `qtt`, this check is not required