### PR TITLE
Fix scanjob_t parsing for negative scan direction

### DIFF
--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -483,10 +483,9 @@ def scan1Dfast(station, scanjob, location=None, liveplotwindow=None, delete=True
 
     is_m4i = _is_m4i(minstrhandle)
     if is_m4i:
-        device_parameters['trigger_re_arm_compensation'] = True
         dt = period*(1-sawtooth_width)/2
         zero_padding = (40+32)/get_sampling_frequency(minstrhandle) - dt
-        print(f'period {period} zero_padding {zero_padding}')
+        logging.info(f'm4i: adding zero_padding to eliminate re-arm time: period {period} zero_padding {zero_padding}')
     else:
         zero_padding = 0
 
@@ -851,7 +850,7 @@ class scanjob_t(dict):
                 raise ValueError('step value may not be 0')
 
             if inclusive_end:
-                epsilon = 1e-8
+                epsilon = np.sign(sweep_data['step'])*1e-8
                 sweep_values = param[sweep_data['start']:(sweep_data['end'] + epsilon):sweep_data['step']]
             else:
                 diff = abs(sweep_data['end'] - sweep_data['start'])
@@ -1812,6 +1811,8 @@ def measuresegment(waveform, Naverage, minstrhandle, read_ch, mV_range=2000, pro
     """
     if device_parameters is None:
         device_parameters = {}
+
+    import qcodes.instrument_drivers.ZI.ZIUHFLI  # delayed import
 
     is_m4i = _is_m4i(minstrhandle)
     is_uhfli = _is_measurement_device(minstrhandle, qcodes.instrument_drivers.ZI.ZIUHFLI.ZIUHFLI)

--- a/src/qtt/measurements/scans.py
+++ b/src/qtt/measurements/scans.py
@@ -484,7 +484,7 @@ def scan1Dfast(station, scanjob, location=None, liveplotwindow=None, delete=True
     is_m4i = _is_m4i(minstrhandle)
     if is_m4i:
         dt = period*(1-sawtooth_width)/2
-        zero_padding = (40+32)/get_sampling_frequency(minstrhandle) - dt
+        zero_padding = max((40+32)/get_sampling_frequency(minstrhandle) - dt, 0)
         logging.info(f'm4i: adding zero_padding to eliminate re-arm time: period {period} zero_padding {zero_padding}')
     else:
         zero_padding = 0

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -23,7 +23,7 @@ from qcodes_contrib_drivers.drivers.Spectrum.M4i import M4i
 
 import qtt.algorithms.onedot
 import qtt.gui.live_plotting
-import qtt.simulation.virtual_dot_array
+import qtt.instrument_drivers.gates
 import qtt.utilities.tools
 from qtt.instrument_drivers.simulation_instruments import SimulationDigitizer
 from qtt.instrument_drivers.virtual_instruments import VirtualIVVI
@@ -522,12 +522,16 @@ class TestScans(TestCase):
         gates.close()
 
     def test_convert_scanjob_vec_regression(self):
-        station = qtt.simulation.virtual_dot_array.initialize()
-
+        station = qcodes.Station()
+        ivvi = VirtualIVVI(name='ivvi', model=None)
+        gates = qtt.instrument_drivers.gates.VirtualDAC(
+            'gates', instruments=[ivvi], gate_map={'P1': (0, 1), 'P2': (0, 2)})
+        station.add_component(gates)
         num = 566
         scanjob = scanjob_t({'minstrument': [1], 'minstrumenthandle': ('m4i', [1]), 'wait_time_startscan': 0.04, 'stepdata': {'wait_time': 0.2}, 'Naverage': 2000, 'sweepdata': {
                             'period': 0.0005, 'param': 'P1', 'range': -5, 'step': -0.01098901098901099, 'start': 714.84130859375, 'end': 709.84130859375}, 'scantype': 'scan1Dfast'})
         _, s = scanjob._convert_scanjob_vec(station=station, sweeplength=num)
         self.assertEqual(len(s), num)
 
-        qtt.simulation.virtual_dot_array.close()
+        gates.close()
+        ivvi.close()

--- a/src/tests/unittests/measurements/test_scans.py
+++ b/src/tests/unittests/measurements/test_scans.py
@@ -19,7 +19,6 @@ from qcodes import ManualParameter, Parameter
 from qcodes.data.data_set import DataSet
 from qcodes.instrument_drivers.devices import VoltageDivider
 from qcodes.instrument_drivers.ZI.ZIUHFLI import ZIUHFLI
-from qcodes_contrib_drivers.drivers.Spectrum.M4i import M4i
 
 import qtt.algorithms.onedot
 import qtt.gui.live_plotting
@@ -33,6 +32,7 @@ from qtt.measurements.scans import (fastScan, get_instrument_parameter, get_samp
 from qtt.structures import MultiParameter
 
 sys.modules['pyspcm'] = MagicMock()
+from qcodes_contrib_drivers.drivers.Spectrum.M4i import M4i
 del sys.modules['pyspcm']
 
 


### PR DESCRIPTION
Minimal example that is fixed with this PR:
```
from qtt.measurements.scans import scanjob_t
import qtt.simulation.virtual_dot_array

station = qtt.simulation.virtual_dot_array.initialize()

num=566
scanjob=scanjob_t({'minstrument': [1], 'minstrumenthandle': ('m4i', [1]), 'wait_time_startscan': 0.04, 'stepdata': {'wait_time': 0.2}, 'Naverage': 2000, 'sweepdata': {'period': 0.0005, 'param': 'P1', 'range': -5, 'step': -0.01098901098901099, 'start': 714.84130859375, 'end': 709.84130859375}, 'scantype': 'scan1Dfast'})
_,s=scanjob._convert_scanjob_vec(station=station, sweeplength=num)
print(s)

assert len(s)==num
```` 
* Fix scanjob_t parsing
* Fix re_arm compensation
* Fix ZI import