### PR TITLE
Fix hom method

### DIFF
--- a/src/qtt/pgeometry.py
+++ b/src/qtt/pgeometry.py
@@ -477,7 +477,7 @@ def hom(x: FloatArray) -> FloatArray:
     Returns:
         An (k+1xN) arrayin homogeneous coordinates
     """
-    return np.vstack((x, np.ones_like(x)))
+    return np.vstack((x, np.ones_like(x, shape=(1, x.shape[1]))))
 
 
 def dehom(x: np.ndarray) -> np.ndarray:

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import qtt.pgeometry as pgeometry
-from qtt.pgeometry import pg_transl2H, point_in_polygon, points_in_polygon, projectiveTransformation
+from qtt.pgeometry import pg_transl2H, point_in_polygon, points_in_polygon, projectiveTransformation, hom
 
 
 class TestPGeometry(unittest.TestCase):
@@ -18,6 +18,13 @@ class TestPGeometry(unittest.TestCase):
 
 class TestGeometryOperations(unittest.TestCase):
 
+    def test_hom(self):
+        pts = np.array([[1,0], [1,1], [2,2]]).T
+        expected = np.array([[1, 1, 2],
+               [0, 1, 2],
+               [1, 1, 1] ])
+        self.assertEqual(hom(pts), expected)
+        
     def test_projectiveTransformation(self):
         x = np.array([[1., 0], [0, 2]])
 

--- a/src/tests/unittests/test_pgeometry.py
+++ b/src/tests/unittests/test_pgeometry.py
@@ -23,7 +23,7 @@ class TestGeometryOperations(unittest.TestCase):
         expected = np.array([[1, 1, 2],
                [0, 1, 2],
                [1, 1, 1] ])
-        self.assertEqual(hom(pts), expected)
+        np.testing.assert_array_almost_equal(hom(pts), expected)
         
     def test_projectiveTransformation(self):
         x = np.array([[1., 0], [0, 2]])


### PR DESCRIPTION
The `qtt.pgeometry.hom` method contained a bug introduced in refactoring.